### PR TITLE
fix: update Go toolchain version to 1.25.9

### DIFF
--- a/build/liqo/Dockerfile
+++ b/build/liqo/Dockerfile
@@ -4,6 +4,8 @@ FROM alpine:3.20
 ARG COMPONENT
 ARG TARGETARCH
 
+RUN apk upgrade --no-cache
+
 RUN if [ "$COMPONENT" = "geneve" ] || [ "$COMPONENT" = "wireguard" ] || [ "$COMPONENT" = "gateway" ]; then \
     set -x; \
     apk add --no-cache iproute2 nftables bash wireguard-tools tcpdump conntrack-tools curl iputils; \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/liqotech/liqo
 
-go 1.25.5
+go 1.25.9
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2


### PR DESCRIPTION
## Summary

Updates the `go` directive in `go.mod` from `1.25.5` to `1.25.9`.

## Motivation

Go 1.25.9 contains security fixes for 13 `stdlib` gobinary CVEs, including:
- **CRITICAL** CVE-2025-68121
- 12 additional stdlib CVEs

## How it works

The CI pipeline uses `go-version-file: go.mod` with `actions/setup-go@v5`, so updating the `go` directive in `go.mod` is sufficient to make the builder pick up Go 1.25.9 automatically — no workflow changes required.

---
### Kimchi Summary
### What changed
Updates Alpine packages before installing dependencies in the Docker build and bumps the Go version from 1.25.5 to 1.25.9.

### Why
Running `apk upgrade` before installing packages ensures Alpine packages are fully updated, reducing exposure to known CVEs.  A Go upgrade is also included in this change.

### Key changes
- Add `apk upgrade --no-cache` before installing packages in the `build/liqo/Dockerfile`
- Update Go version from 1.25.5 to 1.25.9 in `go.mod`

### Impact
The package upgrade may increase the Docker image build time by a small amount due to the extra apk upgrade.