### PR TITLE
fix: upgrade Go toolchain to 1.25.9 and add apk upgrade in Dockerfile

### DIFF
--- a/build/liqo/Dockerfile
+++ b/build/liqo/Dockerfile
@@ -4,6 +4,8 @@ FROM alpine:3.20
 ARG COMPONENT
 ARG TARGETARCH
 
+RUN apk upgrade --no-cache
+
 RUN if [ "$COMPONENT" = "geneve" ] || [ "$COMPONENT" = "wireguard" ] || [ "$COMPONENT" = "gateway" ]; then \
     set -x; \
     apk add --no-cache iproute2 nftables bash wireguard-tools tcpdump conntrack-tools curl iputils; \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/liqotech/liqo
 
-go 1.25.5
+go 1.25.9
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2


### PR DESCRIPTION
## Summary

This PR addresses security vulnerabilities by applying two targeted fixes:

### Step 0: Update Go toolchain version (`go.mod`)
- Bumps the `go` directive from `1.25.5` → `1.25.9` in `go.mod`.
- Ensures the module is built with a patched Go toolchain that resolves CVEs present in earlier `1.25.x` releases.

### Step 1: Add `apk upgrade` to the liqo Dockerfile (`build/liqo/Dockerfile`)
- Inserts `RUN apk upgrade --no-cache` immediately after `ARG TARGETARCH` in the Alpine-based liqo image.
- This upgrades all installed Alpine packages to their latest available versions at image build time, patching any OS-level CVEs (e.g. in musl libc, busybox, and other base-image packages) that exist in `alpine:3.20` at the time of the original image publication.

### Why together?
Both changes are committed atomically to avoid duplicate CI runs and to keep the remediation coherent in a single reviewable diff.

---
### Kimchi Summary
### What changed

Upgrades Go version to 1.25.9 and ensures system packages are updated in the container image by running `apk upgrade` during build.

### Key changes
- **build/liqo/Dockerfile** — Run `apk upgrade --no-cache` before installing additional packages so the base Alpine image gets updated.
- **go.mod** — Bump Go version from 1.25.5 to 1.25.9.

### Impact
- Container images will include the latest security patches at build time.