### PR TITLE
fix: upgrade Go toolchain to 1.25.9 and add apk upgrade in Dockerfile

### DIFF
--- a/build/liqo/Dockerfile
+++ b/build/liqo/Dockerfile
@@ -4,6 +4,8 @@ FROM alpine:3.20
 ARG COMPONENT
 ARG TARGETARCH
 
+RUN apk upgrade --no-cache
+
 RUN if [ "$COMPONENT" = "geneve" ] || [ "$COMPONENT" = "wireguard" ] || [ "$COMPONENT" = "gateway" ]; then \
     set -x; \
     apk add --no-cache iproute2 nftables bash wireguard-tools tcpdump conntrack-tools curl iputils; \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/liqotech/liqo
 
-go 1.25.5
+go 1.25.9
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2


### PR DESCRIPTION
## Summary

This PR addresses vulnerability remediation for the liqo proxy:

### Changes

1. **`go.mod`** – Updated the Go version directive from `1.25.5` → `1.25.9` to pick up the latest Go toolchain security fixes.

2. **`build/liqo/Dockerfile`** – Added `RUN apk upgrade --no-cache` immediately after the `ARG TARGETARCH` line to ensure all Alpine base-image packages are upgraded to their latest patched versions at image build time.

### Why

These changes reduce the CVE exposure surface by:
- Using a patched Go toolchain for the build.
- Ensuring the Alpine runtime image has all available security patches applied during the Docker build.

No markdown files were modified in this PR.

---
### Kimchi Summary
### What changed
This PR updates Go to version 1.25.9 and adds a package upgrade step to the Docker build.

### Why
Running `apk upgrade` during the Docker build ensures the image has the latest package versions and security patches.

### Key changes
- Add `apk upgrade --no-cache` step in the Dockerfile to update installed packages
- Update Go version from 1.25.5 to 1.25.9 in `go.mod`