### PR TITLE
fix: upgrade Go toolchain to 1.25.9 and add apk upgrade in Dockerfile

### DIFF
--- a/build/liqo/Dockerfile
+++ b/build/liqo/Dockerfile
@@ -4,6 +4,8 @@ FROM alpine:3.20
 ARG COMPONENT
 ARG TARGETARCH
 
+RUN apk upgrade --no-cache
+
 RUN if [ "$COMPONENT" = "geneve" ] || [ "$COMPONENT" = "wireguard" ] || [ "$COMPONENT" = "gateway" ]; then \
     set -x; \
     apk add --no-cache iproute2 nftables bash wireguard-tools tcpdump conntrack-tools curl iputils; \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/liqotech/liqo
 
-go 1.25.5
+go 1.25.9
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2


### PR DESCRIPTION
## Summary

This PR addresses two classes of vulnerabilities in the liqo project:

### 1. Go Standard Library CVEs — upgrade Go to 1.25.9

**File changed:** `go.mod` (`go 1.25.5` → `go 1.25.9`)

Upgrading the Go toolchain to 1.25.9 fixes **13 stdlib CVEs**, including:

- **CVE-2025-68121** (Critical) — and 12 additional high/medium severity vulnerabilities in Go standard library packages.

Bumping the `go` directive in `go.mod` ensures the module is built and verified against the patched toolchain version.

### 2. Alpine OS CVEs — add `apk upgrade --no-cache` in Dockerfile

**File changed:** `build/liqo/Dockerfile`

A `RUN apk upgrade --no-cache` step has been inserted immediately after `ARG TARGETARCH`, before any component-specific package installs. This ensures all base Alpine packages are updated to their latest patched versions at image build time, fixing **10 Alpine OS CVEs** in:

- `libcrypto3` / `libssl3`
- `musl` / `musl-utils`
- `zlib`

### Changes

| File | Change |
|------|--------|
| `go.mod` | `go 1.25.5` → `go 1.25.9` |
| `build/liqo/Dockerfile` | Added `RUN apk upgrade --no-cache` after `ARG TARGETARCH` |

---
### Kimchi Summary
### What changed

This PR adds a system package upgrade step during image build and updates the Go version.

### Why

Running `apk upgrade` ensures base packages are patched against known vulnerabilities.

### Key changes

- Adds `apk upgrade --no-cache` in the Dockerfile to update installed packages before the component-specific setup
- Bumps Go version from 1.25.5 to 1.25.9 in `go.mod`