### PR TITLE
fix: upgrade Go toolchain to 1.25.9 and add apk upgrade in Dockerfile

### DIFF
--- a/build/liqo/Dockerfile
+++ b/build/liqo/Dockerfile
@@ -3,6 +3,7 @@
 FROM alpine:3.20
 ARG COMPONENT
 ARG TARGETARCH
+RUN apk upgrade --no-cache
 
 RUN if [ "$COMPONENT" = "geneve" ] || [ "$COMPONENT" = "wireguard" ] || [ "$COMPONENT" = "gateway" ]; then \
     set -x; \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/liqotech/liqo
 
-go 1.25.5
+go 1.25.9
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2


### PR DESCRIPTION
## Summary

This PR addresses vulnerability remediation by:

1. **`go.mod`**: Upgrades the Go toolchain directive from `go 1.25.5` to `go 1.25.9` to pick up upstream security and bug fixes.
2. **`build/liqo/Dockerfile`**: Adds `RUN apk upgrade --no-cache` immediately after `ARG TARGETARCH` to ensure all Alpine base image packages are upgraded to their latest patched versions at build time, eliminating known CVEs in the base image layers.

These changes ensure the rebuilt image is clean of known OS-level and toolchain vulnerabilities.

---
### Kimchi Summary
### What changed

Updates the Go version and adds a system package upgrade step to the container image build.

### Why

Ensures the container image has the latest security patches and bug fixes by upgrading Alpine packages before installing additional software.

### Key changes

- **build/liqo/Dockerfile**: Added `apk upgrade --no-cache` to upgrade existing packages in the Alpine base image before installing additional software, ensuring security fixes are applied.

- **go.mod**: Updated Go version from `1.25.5` to `1.25.9`.