### PR TITLE
fix: upgrade Go to 1.25.9 and apk upgrade to remediate CVEs

### DIFF
--- a/build/liqo/Dockerfile
+++ b/build/liqo/Dockerfile
@@ -4,6 +4,8 @@ FROM alpine:3.20
 ARG COMPONENT
 ARG TARGETARCH
 
+RUN apk upgrade --no-cache
+
 RUN if [ "$COMPONENT" = "geneve" ] || [ "$COMPONENT" = "wireguard" ] || [ "$COMPONENT" = "gateway" ]; then \
     set -x; \
     apk add --no-cache iproute2 nftables bash wireguard-tools tcpdump conntrack-tools curl iputils; \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/liqotech/liqo
 
-go 1.25.5
+go 1.25.9
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2


### PR DESCRIPTION
## Summary

This PR addresses several CVEs across two layers of the liqo container image:

### 1. Go toolchain upgrade (`go.mod`)

Updates the Go version directive from `go 1.25.5` → `go 1.25.9` to pull in fixes for Go standard-library CVEs, including:

- **CVE-2025-68121** *(CRITICAL)* – vulnerability in the Go standard library affecting versions prior to 1.25.9.
- Additional medium/high severity CVEs in Go stdlib components fixed in the 1.25.x patch series.

### 2. Alpine OS package upgrade (`build/liqo/Dockerfile`)

Adds `RUN apk upgrade --no-cache` immediately after the `ARG TARGETARCH` line so that all Alpine base-image packages are upgraded to their latest patched versions at build time. This remediates OS-level CVEs including:

- **libcrypto3 / libssl3** – multiple CVEs in OpenSSL shipped with Alpine 3.20.
- **musl / musl-utils** – CVEs in the musl libc bundled with Alpine 3.20.
- **zlib** – CVE in the zlib compression library.

### Files changed

| File | Change |
|------|--------|
| `go.mod` | `go 1.25.5` → `go 1.25.9` |
| `build/liqo/Dockerfile` | Added `RUN apk upgrade --no-cache` after `ARG TARGETARCH` |

---
### Kimchi Summary
### What changed
Updates Go version and adds a system upgrade step to the Dockerfile for security improvements.

### Why
Upgrading packages and the Go version addresses potential security vulnerabilities and ensures the build stays current.

### Key changes
- Added `apk upgrade` step in `build/liqo/Dockerfile` to upgrade all packages before installing dependencies
- Updated Go version from 1.25.5 to 1.25.9 in `go.mod`

### Impact
Running `apk upgrade` ensures the container base image packages are up to date, reducing potential vulnerabilities from outdated packages.