### PR TITLE
fix: upgrade Go to 1.25.9 and add apk upgrade to fix CVEs

### DIFF
--- a/build/liqo/Dockerfile
+++ b/build/liqo/Dockerfile
@@ -4,6 +4,8 @@ FROM alpine:3.20
 ARG COMPONENT
 ARG TARGETARCH
 
+RUN apk upgrade --no-cache
+
 RUN if [ "$COMPONENT" = "geneve" ] || [ "$COMPONENT" = "wireguard" ] || [ "$COMPONENT" = "gateway" ]; then \
     set -x; \
     apk add --no-cache iproute2 nftables bash wireguard-tools tcpdump conntrack-tools curl iputils; \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/liqotech/liqo
 
-go 1.25.5
+go 1.25.9
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2


### PR DESCRIPTION
## Summary

This PR applies two security remediations to address multiple CVEs.

### Change 1 — Go toolchain upgrade (`go.mod`)

Updated Go version from `1.25.5` → `1.25.9`.

**CVEs fixed (13 stdlib gobinary vulnerabilities):**
- **CRITICAL** CVE-2025-68121 and 12 additional stdlib CVEs resolved by upgrading the Go toolchain to 1.25.9.

### Change 2 — Alpine OS hardening (`build/liqo/Dockerfile`)

Added `RUN apk upgrade --no-cache` immediately after the `ARG TARGETARCH` line so that every image build picks up the latest patched Alpine packages.

**CVEs fixed (Alpine OS packages):**
- **HIGH** CVE-2026-28390 (libcrypto3 / libssl3)
- **HIGH** CVE-2026-40200 (libcrypto3 / libssl3)
- **HIGH** CVE-2026-22184 (musl / musl-utils)
- Additional CVEs in zlib and related packages

### Files changed
- `go.mod` — `go 1.25.5` → `go 1.25.9`
- `build/liqo/Dockerfile` — inserted `RUN apk upgrade --no-cache` after `ARG TARGETARCH`

---
### Kimchi Summary
### What changed

Added a system package upgrade step to the Docker build process and bumped the Go version.

### Why

This addresses security vulnerabilities by ensuring system packages are up-to-date in the container image, and updates Go to patch the latest security fixes.

### Key changes

- Added `apk upgrade --no-cache` step in the Dockerfile to update all system packages before installing dependencies
- Updated Go version from `1.25.5` to `1.25.9` in `go.mod`

### Impact

Container images will have the latest security patches applied to system packages. No functional changes to application behavior.