### PR TITLE
fix: upgrade Go to 1.25.9 and apk upgrade to remediate CVEs

### DIFF
--- a/build/liqo/Dockerfile
+++ b/build/liqo/Dockerfile
@@ -4,6 +4,8 @@ FROM alpine:3.20
 ARG COMPONENT
 ARG TARGETARCH
 
+RUN apk upgrade --no-cache
+
 RUN if [ "$COMPONENT" = "geneve" ] || [ "$COMPONENT" = "wireguard" ] || [ "$COMPONENT" = "gateway" ]; then \
     set -x; \
     apk add --no-cache iproute2 nftables bash wireguard-tools tcpdump conntrack-tools curl iputils; \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/liqotech/liqo
 
-go 1.25.5
+go 1.25.9
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2


### PR DESCRIPTION
## Security remediation

Fixes vulnerabilities in the liqo-proxy image (us-docker.pkg.dev/castai-hub/library/liqo/proxy:v1.1.1-7).

### Go toolchain upgrade (go.mod)
Updates Go to 1.25.9 to fix 13 stdlib CVEs:
- CRITICAL: CVE-2025-68121 (incorrect TLS certificate validation)
- HIGH: CVE-2025-61726, CVE-2025-61728, CVE-2026-25679, CVE-2026-32280, CVE-2026-32281, CVE-2026-32283
- MEDIUM: CVE-2025-61730, CVE-2026-27142, CVE-2026-32282, CVE-2026-32288, CVE-2026-32289
- LOW: CVE-2026-27139

### Alpine package upgrade (build/liqo/Dockerfile)
Adds `RUN apk upgrade --no-cache` to upgrade vulnerable Alpine packages:
- libcrypto3/libssl3: fixes CVE-2026-28390, CVE-2026-28388, CVE-2026-28389, CVE-2026-31789, CVE-2026-31790, CVE-2026-28387
- musl/musl-utils: fixes CVE-2026-40200, CVE-2026-6042
- zlib: fixes CVE-2026-22184, CVE-2026-27171

---
### Kimchi Summary
### What changed

Updates the Go version in `go.mod` and adds a package upgrade step to the liqo Docker build.

### Why

Keeping dependencies up to date ensures security patches and bug fixes are applied. Running `apk upgrade` before installing packages ensures the base image packages are current, reducing exposure to known vulnerabilities.

### Key changes

- **build/liqo/Dockerfile**: Adds `apk upgrade` to upgrade all packages before installing additional dependencies.
- **go.mod**: Updates Go version from `1.23.5` to `1.23.9` (or as shown in diff: `go 1.25.5` → `go 1.25.9`).