### PR TITLE
feat: strip cast related resources from reflected pods

### DIFF
--- a/pkg/virtualKubelet/forge/pods.go
+++ b/pkg/virtualKubelet/forge/pods.go
@@ -194,6 +194,7 @@ func RemoteShadowPod(local *corev1.Pod, remote *offloadingv1beta1.ShadowPod,
 	}
 
 	mutators = append(mutators, RuntimeClassNameMutator(local, forgingOpts))
+	mutators = append(mutators, CastResourcesMutator())
 
 	return &offloadingv1beta1.ShadowPod{
 		ObjectMeta: RemoteObjectMeta(localMetaFiltered, &remote.ObjectMeta),
@@ -451,6 +452,31 @@ func FilterAntiAffinityLabels(labels map[string]string, whitelist string) map[st
 
 	return maps.Filter(labels, maps.FilterBlacklist(appsv1.ControllerRevisionHashLabelKey,
 		appsv1.DefaultDeploymentUniqueLabelKey, appsv1.StatefulSetPodNameLabel))
+}
+
+// CastResourcesMutator is a mutator which strips cast.ai-related resource requests/limits
+// (e.g. scheduling.cast.ai/network-bandwidth) from containers, as these are already reflected on virtual node.
+func CastResourcesMutator() RemotePodSpecMutator {
+	stripCastResources := func(rl corev1.ResourceList) corev1.ResourceList {
+		for k := range rl {
+			if strings.Contains(string(k), "cast.ai/") {
+				delete(rl, k)
+			}
+		}
+		return rl
+	}
+
+	stripContainers := func(containers []corev1.Container) {
+		for i := range containers {
+			containers[i].Resources.Requests = stripCastResources(containers[i].Resources.Requests)
+			containers[i].Resources.Limits = stripCastResources(containers[i].Resources.Limits)
+		}
+	}
+
+	return func(remote *corev1.PodSpec) {
+		stripContainers(remote.Containers)
+		stripContainers(remote.InitContainers)
+	}
 }
 
 // RuntimeClassNameMutator is a mutator which implements the support to propagate the runtimeclass name.

--- a/pkg/virtualKubelet/forge/pods_test.go
+++ b/pkg/virtualKubelet/forge/pods_test.go
@@ -591,6 +591,70 @@ var _ = Describe("Pod forging", func() {
 		})
 	})
 
+	Describe("the CastResourcesMutator function", func() {
+		var remote *corev1.PodSpec
+
+		BeforeEach(func() {
+			remote = &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "c1",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:                     resource.MustParse("100m"),
+								"scheduling.cast.ai/network-bandwidth": resource.MustParse("10"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory:                  resource.MustParse("128Mi"),
+								"scheduling.cast.ai/network-bandwidth": resource.MustParse("20"),
+								"cast.ai/foo":                          resource.MustParse("1"),
+							},
+						},
+					},
+				},
+				InitContainers: []corev1.Container{
+					{
+						Name: "i1",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:                     resource.MustParse("50m"),
+								"scheduling.cast.ai/network-bandwidth": resource.MustParse("5"),
+							},
+							Limits: corev1.ResourceList{
+								"other.cast.ai/something": resource.MustParse("3"),
+							},
+						},
+					},
+				},
+			}
+		})
+
+		JustBeforeEach(func() { forge.CastResourcesMutator()(remote) })
+
+		It("should strip cast.ai resources from container requests", func() {
+			Expect(remote.Containers[0].Resources.Requests).To(HaveKey(corev1.ResourceCPU))
+			Expect(remote.Containers[0].Resources.Requests).NotTo(HaveKey(corev1.ResourceName("scheduling.cast.ai/network-bandwidth")))
+		})
+
+		It("should strip cast.ai resources from container limits", func() {
+			Expect(remote.Containers[0].Resources.Limits).To(HaveKey(corev1.ResourceMemory))
+			Expect(remote.Containers[0].Resources.Limits).NotTo(HaveKey(corev1.ResourceName("scheduling.cast.ai/network-bandwidth")))
+			Expect(remote.Containers[0].Resources.Limits).NotTo(HaveKey(corev1.ResourceName("cast.ai/foo")))
+		})
+
+		It("should strip cast.ai resources from init container requests and limits", func() {
+			Expect(remote.InitContainers[0].Resources.Requests).To(HaveKey(corev1.ResourceCPU))
+			Expect(remote.InitContainers[0].Resources.Requests).NotTo(HaveKey(corev1.ResourceName("scheduling.cast.ai/network-bandwidth")))
+			Expect(remote.InitContainers[0].Resources.Limits).NotTo(HaveKey(corev1.ResourceName("other.cast.ai/something")))
+		})
+
+		It("should preserve standard resources", func() {
+			Expect(remote.Containers[0].Resources.Requests[corev1.ResourceCPU]).To(Equal(resource.MustParse("100m")))
+			Expect(remote.Containers[0].Resources.Limits[corev1.ResourceMemory]).To(Equal(resource.MustParse("128Mi")))
+			Expect(remote.InitContainers[0].Resources.Requests[corev1.ResourceCPU]).To(Equal(resource.MustParse("50m")))
+		})
+	})
+
 	Describe("the RemoteContainersAPIServerSupport function", func() {
 		var container corev1.Container
 		var output []corev1.Container


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

---
### Kimchi Summary
### What changed
Adds a `CastResourcesMutator` to strip cast.ai-specific extended resources (e.g., `scheduling.cast.ai/network-bandwidth`) from container resource requests and limits when forging remote `ShadowPod` specs.

### Why
Cast.ai-specific resources are already reflected at the virtual node level, so including them in offloaded pod specs creates unnecessary duplication and potential scheduling conflicts.

### Key changes
- `pkg/virtualKubelet/forge/pods.go`:
  - Added `CastResourcesMutator()` function that removes any resource names containing `"cast.ai/"` from both `Requests` and `Limits` of regular and init containers
  - Integrated the mutator into the `RemoteShadowPod` function alongside existing mutators
- `pkg/virtualKubelet/forge/pods_test.go`: Added comprehensive test coverage verifying cast.ai resources are stripped while standard resources (CPU, memory) are preserved for both containers and init containers