### PR TITLE
feat: initial DRA support

### DIFF
--- a/cmd/virtual-kubelet/root/opts.go
+++ b/cmd/virtual-kubelet/root/opts.go
@@ -57,6 +57,8 @@ var DefaultReflectorsWorkers = map[resources.ResourceReflected]uint{
 	resources.ServiceAccount:        3,
 	resources.PersistentVolumeClaim: 3,
 	resources.Event:                 3,
+	resources.ResourceSlice:         1,
+	resources.ResourceClaim:         3,
 }
 
 // DefaultReflectorsTypes contains the default type of reflection for each reflected resource.
@@ -69,6 +71,8 @@ var DefaultReflectorsTypes = map[resources.ResourceReflected]offloadingv1beta1.R
 	resources.ServiceAccount:        offloadingv1beta1.CustomLiqo,
 	resources.PersistentVolumeClaim: offloadingv1beta1.CustomLiqo,
 	resources.Event:                 offloadingv1beta1.DenyList,
+	resources.ResourceSlice:         offloadingv1beta1.CustomLiqo,
+	resources.ResourceClaim:         offloadingv1beta1.CustomLiqo,
 }
 
 // Opts stores all the options for configuring the root virtual-kubelet command.

--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -408,7 +408,11 @@ func getVersion(config *rest.Config) string {
 }
 
 func isReflectionTypeNotCustomizable(resource resources.ResourceReflected) bool {
-	return resource == resources.Pod || resource == resources.ServiceAccount || resource == resources.PersistentVolumeClaim
+	return resource == resources.Pod ||
+		resource == resources.ServiceAccount ||
+		resource == resources.PersistentVolumeClaim ||
+		resource == resources.ResourceSlice ||
+		resource == resources.ResourceClaim
 }
 
 func getReflectorsConfigs(c *Opts) (map[resources.ResourceReflected]offloadingv1beta1.ReflectorConfig, error) {

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -154,6 +154,8 @@
 | offloading.reflection.ingress.workers | int | `3` | The number of workers used for the ingresses reflector. Set 0 to disable the reflection of ingresses. |
 | offloading.reflection.persistentvolumeclaim.workers | int | `3` | The number of workers used for the persistentvolumeclaims reflector. Set 0 to disable the reflection of persistentvolumeclaims. |
 | offloading.reflection.pod.workers | int | `10` | The number of workers used for the pods reflector. Set 0 to disable the reflection of pods. |
+| offloading.reflection.resourceclaim.workers | int | `3` | The number of workers used for the DRA ResourceClaim reflector. Set 0 to disable the reflection of ResourceClaims. Reflection is also automatically skipped if the resource.k8s.io/v1 API is not available on either cluster. |
+| offloading.reflection.resourceslice.workers | int | `1` | The number of workers used for the DRA ResourceSlice reflector (leader-only). Set 0 to disable the reflection of ResourceSlices. Reflection is also automatically skipped if the resource.k8s.io/v1 API is not available on either cluster. |
 | offloading.reflection.secret.type | string | `"DenyList"` | The type of reflection used for the secrets reflector. Ammitted values: "DenyList", "AllowList". |
 | offloading.reflection.secret.workers | int | `3` | The number of workers used for the secrets reflector. Set 0 to disable the reflection of secrets. |
 | offloading.reflection.service.loadBalancerClasses | list | `[]` | List of load balancer classes that will be shown to remote clusters. If empty, load balancer classes will be reflected as-is. Example: loadBalancerClasses: - name: public   default: true - name: internal |

--- a/deployments/liqo/files/liqo-virtual-kubelet-local-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-virtual-kubelet-local-ClusterRole.yaml
@@ -125,6 +125,27 @@ rules:
   - list
   - watch
 - apiGroups:
+  - resource.k8s.io
+  resources:
+  - deviceclasses
+  - resourceclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses

--- a/deployments/liqo/files/liqo-virtual-kubelet-remote-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-virtual-kubelet-remote-ClusterRole.yaml
@@ -70,3 +70,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/deployments/liqo/files/liqo-virtual-kubelet-remote-clusterwide-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-virtual-kubelet-remote-clusterwide-ClusterRole.yaml
@@ -15,3 +15,20 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - deviceclasses
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceslices
+  verbs:
+  - get
+  - list
+  - watch

--- a/deployments/liqo/templates/liqo-vk-options-template.yaml
+++ b/deployments/liqo/templates/liqo-vk-options-template.yaml
@@ -69,6 +69,10 @@ spec:
     event:
       workers: {{ .Values.offloading.reflection.event.workers }}
       type: {{ .Values.offloading.reflection.event.type }}
+    resourceslice:
+      workers: {{ .Values.offloading.reflection.resourceslice.workers }}
+    resourceclaim:
+      workers: {{ .Values.offloading.reflection.resourceclaim.workers }}
   {{- if .Values.virtualKubelet.extra.resources }}
   resources:
     {{- toYaml .Values.virtualKubelet.extra.resources | nindent 4 }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -358,6 +358,16 @@ offloading:
       workers: 3
       # -- The type of reflection used for the events reflector. Ammitted values: "DenyList", "AllowList".
       type: DenyList
+    resourceslice:
+      # -- The number of workers used for the DRA ResourceSlice reflector (leader-only).
+      # Set 0 to disable the reflection of ResourceSlices. Reflection is also automatically
+      # skipped if the resource.k8s.io/v1 API is not available on either cluster.
+      workers: 1
+    resourceclaim:
+      # -- The number of workers used for the DRA ResourceClaim reflector. Set 0 to disable
+      # the reflection of ResourceClaims. Reflection is also automatically skipped if the
+      # resource.k8s.io/v1 API is not available on either cluster.
+      workers: 3
 
 storage:
   # -- Enable/Disable the liqo virtual storage class on the local cluster. You will be able to

--- a/pkg/utils/cluster_info.go
+++ b/pkg/utils/cluster_info.go
@@ -112,6 +112,10 @@ func GetRestConfig(configPath string) (config *rest.Config, err error) {
 		config, err = rest.InClusterConfig()
 	}
 
+	if err != nil {
+		return nil, err
+	}
+
 	config.Timeout = 10 * time.Second
 
 	return config, err

--- a/pkg/virtualKubelet/forge/dra.go
+++ b/pkg/virtualKubelet/forge/dra.go
@@ -1,0 +1,116 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forge
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/ptr"
+)
+
+// LocalResourceSlice builds the local ResourceSlice from the given remote slice,
+// setting its OwnerReference to the local virtual node. The caller is responsible for
+// having checked that remote.Spec.NodeName is set and matches a local node.
+// Important: this function is based on the assumption that the local node name is the same as the remote one.
+func LocalResourceSlice(
+	remote *resourcev1.ResourceSlice,
+	localNode *corev1.Node,
+	labelsNotReflected, annotationsNotReflected []string,
+) *resourcev1.ResourceSlice {
+	return &resourcev1.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: remote.Name,
+			Labels: labels.Merge(
+				FilterNotReflected(remote.GetLabels(), labelsNotReflected),
+				ReflectionLabels(),
+			),
+			Annotations: FilterNotReflected(remote.GetAnnotations(), annotationsNotReflected),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "v1",
+					Kind:               "Node",
+					Name:               localNode.Name,
+					UID:                localNode.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(false),
+				},
+			},
+		},
+		Spec: *remote.Spec.DeepCopy(),
+	}
+}
+
+// RemoteResourceClaim builds a remote ResourceClaim from a local one, dropping
+// status and server-managed metadata.
+func RemoteResourceClaim(local *resourcev1.ResourceClaim, remoteNamespace string,
+	labelsNotReflected, annotationsNotReflected []string) *resourcev1.ResourceClaim {
+	return &resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      local.Name,
+			Namespace: remoteNamespace,
+			Labels: labels.Merge(
+				FilterNotReflected(local.GetLabels(), labelsNotReflected),
+				ReflectionLabels(),
+			),
+			Annotations: FilterNotReflected(local.GetAnnotations(), annotationsNotReflected),
+		},
+		Spec: *local.Spec.DeepCopy(),
+	}
+}
+
+// RemoteDeviceClass builds a remote DeviceClass from a local one. DeviceClass is
+// cluster-scoped; we keep the same name and copy the spec verbatim.
+func RemoteDeviceClass(local *resourcev1.DeviceClass, labelsNotReflected, annotationsNotReflected []string) *resourcev1.DeviceClass {
+	return &resourcev1.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: local.Name,
+			Labels: labels.Merge(
+				FilterNotReflected(local.GetLabels(), labelsNotReflected),
+				ReflectionLabels(),
+			),
+			Annotations: FilterNotReflected(local.GetAnnotations(), annotationsNotReflected),
+		},
+		Spec: *local.Spec.DeepCopy(),
+	}
+}
+
+// ReferencedDeviceClasses extracts the set of DeviceClass names referenced by a
+// ResourceClaim, walking both Exactly and FirstAvailable sub-requests.
+func ReferencedDeviceClasses(claim *resourcev1.ResourceClaim) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	for i := range claim.Spec.Devices.Requests {
+		req := &claim.Spec.Devices.Requests[i]
+		if req.Exactly != nil {
+			add(req.Exactly.DeviceClassName)
+		}
+		for j := range req.FirstAvailable {
+			add(req.FirstAvailable[j].DeviceClassName)
+		}
+	}
+	return out
+}

--- a/pkg/virtualKubelet/forge/dra_test.go
+++ b/pkg/virtualKubelet/forge/dra_test.go
@@ -1,0 +1,354 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forge_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
+)
+
+const (
+	barVal            = "bar"
+	bazVal            = "baz"
+	fooVal            = "foo"
+	trueVal           = "true"
+	fakeMutatedValue  = "mutated"
+	fakeGPUClassValue = "gpu-class"
+	fakeGPUValue      = "gpu"
+	fakeFPGAValue     = "fpga"
+)
+
+var _ = Describe("DRA forging", func() {
+
+	Describe("the LocalResourceSlice function", func() {
+		var (
+			remote *resourcev1.ResourceSlice
+			node   *corev1.Node
+			output *resourcev1.ResourceSlice
+			opts   *forge.ForgingOpts
+		)
+
+		BeforeEach(func() {
+			remote = &resourcev1.ResourceSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "slice",
+					Labels: map[string]string{
+						fooVal:                            barVal,
+						testutil.FakeNotReflectedLabelKey: trueVal,
+					},
+					Annotations: map[string]string{
+						barVal:                            bazVal,
+						testutil.FakeNotReflectedAnnotKey: trueVal,
+					},
+				},
+				Spec: resourcev1.ResourceSliceSpec{
+					Driver:   "test-driver",
+					NodeName: ptr.To("remote-node"),
+					Pool: resourcev1.ResourcePool{
+						Name:               "pool-a",
+						Generation:         3,
+						ResourceSliceCount: 1,
+					},
+					Devices: []resourcev1.Device{{Name: "dev-1"}},
+				},
+			}
+			node = &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: LiqoNodeName,
+					UID:  types.UID("node-uid-123"),
+				},
+			}
+			opts = testutil.FakeForgingOpts()
+		})
+
+		JustBeforeEach(func() {
+			output = forge.LocalResourceSlice(remote, node, opts.LabelsNotReflected, opts.AnnotationsNotReflected)
+		})
+
+		It("should preserve the slice name", func() {
+			Expect(output.Name).To(Equal("slice"))
+		})
+
+		It("should merge reflection labels with the originals", func() {
+			Expect(output.Labels).To(HaveKeyWithValue(fooVal, barVal))
+			Expect(output.Labels).To(HaveKeyWithValue(forge.LiqoOriginClusterIDKey, string(LocalClusterID)))
+			Expect(output.Labels).To(HaveKeyWithValue(forge.LiqoDestinationClusterIDKey, string(RemoteClusterID)))
+		})
+
+		It("should filter out the not-reflected label/annotation keys", func() {
+			Expect(output.Labels).ToNot(HaveKey(testutil.FakeNotReflectedLabelKey))
+			Expect(output.Annotations).To(HaveKeyWithValue(barVal, bazVal))
+			Expect(output.Annotations).ToNot(HaveKey(testutil.FakeNotReflectedAnnotKey))
+		})
+
+		It("should set a single OwnerReference pointing at the local node", func() {
+			Expect(output.OwnerReferences).To(HaveLen(1))
+			ref := output.OwnerReferences[0]
+			Expect(ref.APIVersion).To(Equal("v1"))
+			Expect(ref.Kind).To(Equal("Node"))
+			Expect(ref.Name).To(Equal(node.Name))
+			Expect(ref.UID).To(Equal(node.UID))
+			Expect(ref.Controller).To(PointTo(BeTrue()))
+			Expect(ref.BlockOwnerDeletion).To(PointTo(BeFalse()))
+		})
+
+		It("should deep-copy the spec (mutating remote does not affect the output)", func() {
+			Expect(output.Spec.Driver).To(Equal("test-driver"))
+			remote.Spec.Driver = fakeMutatedValue
+			remote.Spec.Devices[0].Name = "mutated-dev"
+			Expect(output.Spec.Driver).To(Equal("test-driver"))
+			Expect(output.Spec.Devices[0].Name).To(Equal("dev-1"))
+		})
+
+		When("the remote has nil labels and annotations", func() {
+			BeforeEach(func() {
+				remote.Labels = nil
+				remote.Annotations = nil
+			})
+			It("should still produce reflection labels without panicking", func() {
+				Expect(output.Labels).To(HaveKeyWithValue(forge.LiqoOriginClusterIDKey, string(LocalClusterID)))
+				Expect(output.Labels).To(HaveKeyWithValue(forge.LiqoDestinationClusterIDKey, string(RemoteClusterID)))
+			})
+		})
+
+		When("the remote labels conflict with reflection-managed keys", func() {
+			BeforeEach(func() {
+				remote.Labels[forge.LiqoOriginClusterIDKey] = "some-other-cluster"
+			})
+			It("should let reflection labels win the merge", func() {
+				Expect(output.Labels).To(HaveKeyWithValue(forge.LiqoOriginClusterIDKey, string(LocalClusterID)))
+			})
+		})
+	})
+
+	Describe("the RemoteResourceClaim function", func() {
+		const (
+			localNamespace  = "local-namespace"
+			remoteNamespace = "remote-namespace"
+		)
+
+		var (
+			local  *resourcev1.ResourceClaim
+			output *resourcev1.ResourceClaim
+			opts   *forge.ForgingOpts
+		)
+
+		BeforeEach(func() {
+			local = &resourcev1.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "claim",
+					Namespace: localNamespace,
+					Labels: map[string]string{
+						fooVal:                            barVal,
+						testutil.FakeNotReflectedLabelKey: trueVal,
+					},
+					Annotations: map[string]string{
+						barVal:                            bazVal,
+						testutil.FakeNotReflectedAnnotKey: trueVal,
+					},
+				},
+				Spec: resourcev1.ResourceClaimSpec{
+					Devices: resourcev1.DeviceClaim{
+						Requests: []resourcev1.DeviceRequest{{
+							Name: "req-1",
+							Exactly: &resourcev1.ExactDeviceRequest{
+								DeviceClassName: fakeGPUClassValue,
+								Count:           1,
+							},
+						}},
+					},
+				},
+				Status: resourcev1.ResourceClaimStatus{
+					Allocation: &resourcev1.AllocationResult{
+						Devices: resourcev1.DeviceAllocationResult{
+							Results: []resourcev1.DeviceRequestAllocationResult{{Driver: "x"}},
+						},
+					},
+				},
+			}
+			opts = testutil.FakeForgingOpts()
+		})
+
+		JustBeforeEach(func() {
+			output = forge.RemoteResourceClaim(local, remoteNamespace, opts.LabelsNotReflected, opts.AnnotationsNotReflected)
+		})
+
+		It("should preserve the name and remap the namespace", func() {
+			Expect(output.Name).To(Equal("claim"))
+			Expect(output.Namespace).To(Equal(remoteNamespace))
+		})
+
+		It("should merge reflection labels and filter not-reflected keys", func() {
+			Expect(output.Labels).To(HaveKeyWithValue(fooVal, barVal))
+			Expect(output.Labels).To(HaveKeyWithValue(forge.LiqoOriginClusterIDKey, string(LocalClusterID)))
+			Expect(output.Labels).To(HaveKeyWithValue(forge.LiqoDestinationClusterIDKey, string(RemoteClusterID)))
+			Expect(output.Labels).ToNot(HaveKey(testutil.FakeNotReflectedLabelKey))
+			Expect(output.Annotations).To(HaveKeyWithValue(barVal, bazVal))
+			Expect(output.Annotations).ToNot(HaveKey(testutil.FakeNotReflectedAnnotKey))
+		})
+
+		It("should deep-copy the spec", func() {
+			Expect(output.Spec.Devices.Requests[0].Exactly.DeviceClassName).To(Equal(fakeGPUClassValue))
+			local.Spec.Devices.Requests[0].Exactly.DeviceClassName = fakeMutatedValue
+			Expect(output.Spec.Devices.Requests[0].Exactly.DeviceClassName).To(Equal(fakeGPUClassValue))
+		})
+
+		It("should not propagate status (allocation is owned by remote)", func() {
+			Expect(output.Status).To(Equal(resourcev1.ResourceClaimStatus{}))
+		})
+
+		When("the local has nil labels and annotations", func() {
+			BeforeEach(func() {
+				local.Labels = nil
+				local.Annotations = nil
+			})
+			It("should still produce reflection labels without panicking", func() {
+				Expect(output.Labels).To(HaveKeyWithValue(forge.LiqoOriginClusterIDKey, string(LocalClusterID)))
+			})
+		})
+	})
+
+	Describe("the RemoteDeviceClass function", func() {
+		var (
+			local  *resourcev1.DeviceClass
+			output *resourcev1.DeviceClass
+			opts   *forge.ForgingOpts
+		)
+
+		BeforeEach(func() {
+			local = &resourcev1.DeviceClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fakeGPUClassValue,
+					Labels: map[string]string{
+						fooVal:                            barVal,
+						testutil.FakeNotReflectedLabelKey: trueVal,
+					},
+					Annotations: map[string]string{
+						barVal:                            bazVal,
+						testutil.FakeNotReflectedAnnotKey: trueVal,
+					},
+				},
+				Spec: resourcev1.DeviceClassSpec{
+					Selectors: []resourcev1.DeviceSelector{
+						{CEL: &resourcev1.CELDeviceSelector{Expression: "device.attributes.foo == \"bar\""}},
+					},
+				},
+			}
+			opts = testutil.FakeForgingOpts()
+		})
+
+		JustBeforeEach(func() {
+			output = forge.RemoteDeviceClass(local, opts.LabelsNotReflected, opts.AnnotationsNotReflected)
+		})
+
+		It("should preserve the cluster-scoped name", func() {
+			Expect(output.Name).To(Equal(fakeGPUClassValue))
+			Expect(output.Namespace).To(BeEmpty())
+		})
+
+		It("should merge reflection labels and filter not-reflected keys", func() {
+			Expect(output.Labels).To(HaveKeyWithValue(fooVal, barVal))
+			Expect(output.Labels).To(HaveKeyWithValue(forge.LiqoOriginClusterIDKey, string(LocalClusterID)))
+			Expect(output.Labels).ToNot(HaveKey(testutil.FakeNotReflectedLabelKey))
+			Expect(output.Annotations).To(HaveKeyWithValue(barVal, bazVal))
+			Expect(output.Annotations).ToNot(HaveKey(testutil.FakeNotReflectedAnnotKey))
+		})
+
+		It("should deep-copy the spec", func() {
+			Expect(output.Spec.Selectors).To(HaveLen(1))
+			local.Spec.Selectors[0].CEL.Expression = fakeMutatedValue
+			Expect(output.Spec.Selectors[0].CEL.Expression).To(Equal("device.attributes.foo == \"bar\""))
+		})
+	})
+
+	Describe("the ReferencedDeviceClasses function", func() {
+		newClaimWithRequests := func(reqs ...resourcev1.DeviceRequest) *resourcev1.ResourceClaim {
+			return &resourcev1.ResourceClaim{Spec: resourcev1.ResourceClaimSpec{
+				Devices: resourcev1.DeviceClaim{Requests: reqs},
+			}}
+		}
+
+		It("should return the single Exactly DeviceClassName", func() {
+			out := forge.ReferencedDeviceClasses(newClaimWithRequests(
+				resourcev1.DeviceRequest{Name: "exactDevice", Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: fakeGPUValue}},
+			))
+			Expect(out).To(ConsistOf(fakeGPUValue))
+		})
+
+		It("should deduplicate Exactly entries that reference the same class", func() {
+			out := forge.ReferencedDeviceClasses(newClaimWithRequests(
+				resourcev1.DeviceRequest{Name: "ded1", Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: fakeGPUValue}},
+				resourcev1.DeviceRequest{Name: "ded2", Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: fakeGPUValue}},
+				resourcev1.DeviceRequest{Name: "ded3", Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: fakeFPGAValue}},
+			))
+			Expect(out).To(ConsistOf(fakeGPUValue, fakeFPGAValue))
+		})
+
+		It("should extract names from FirstAvailable subrequests", func() {
+			out := forge.ReferencedDeviceClasses(newClaimWithRequests(
+				resourcev1.DeviceRequest{
+					Name: "firstAvailable1",
+					FirstAvailable: []resourcev1.DeviceSubRequest{
+						{Name: "firstAvailableSub1", DeviceClassName: fakeGPUValue},
+						{Name: "firstAvailableSub2", DeviceClassName: fakeFPGAValue},
+					},
+				},
+			))
+			Expect(out).To(ConsistOf(fakeGPUValue, fakeFPGAValue))
+		})
+
+		It("should deduplicate across Exactly and FirstAvailable", func() {
+			out := forge.ReferencedDeviceClasses(newClaimWithRequests(
+				resourcev1.DeviceRequest{Name: "exactDevice1", Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: fakeGPUValue}},
+				resourcev1.DeviceRequest{
+					Name: "exactDevice2",
+					FirstAvailable: []resourcev1.DeviceSubRequest{
+						{Name: "exactDevice2Sub1", DeviceClassName: fakeGPUValue},
+						{Name: "exactDevice2Sub2", DeviceClassName: fakeFPGAValue},
+					},
+				},
+			))
+			Expect(out).To(ConsistOf(fakeGPUValue, fakeFPGAValue))
+		})
+
+		It("should return an empty slice for an empty Requests list", func() {
+			out := forge.ReferencedDeviceClasses(newClaimWithRequests())
+			Expect(out).To(BeEmpty())
+		})
+
+		It("should skip empty-string DeviceClassName entries", func() {
+			out := forge.ReferencedDeviceClasses(newClaimWithRequests(
+				resourcev1.DeviceRequest{Name: "emptyClassName", Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: ""}},
+				resourcev1.DeviceRequest{
+					Name: "emptyClassName2",
+					FirstAvailable: []resourcev1.DeviceSubRequest{
+						{Name: "emptyClassNameSub1", DeviceClassName: ""},
+						{Name: "emptyClassNameSub2", DeviceClassName: fakeFPGAValue},
+					},
+				},
+			))
+			Expect(out).To(ConsistOf(fakeFPGAValue))
+		})
+	})
+})

--- a/pkg/virtualKubelet/forge/pods.go
+++ b/pkg/virtualKubelet/forge/pods.go
@@ -98,6 +98,15 @@ func LocalPodOffloadedLabel(local *corev1.Pod) (*corev1apply.PodApplyConfigurati
 		WithLabels(map[string]string{liqoconst.LocalPodLabelKey: liqoconst.LocalPodLabelValue}), true
 }
 
+// PreserveResourceClaimStatusesMutator returns a RemotePodStatusMutator that restores
+// the local pod's ResourceClaimStatuses after the remote status is applied. These are
+// managed by the local kubelet and must not be overwritten with the remote's view.
+func PreserveResourceClaimStatusesMutator(local []corev1.PodResourceClaimStatus) RemotePodStatusMutator {
+	return func(remote *corev1.PodStatus) {
+		remote.ResourceClaimStatuses = local
+	}
+}
+
 // LocalPodStatus forges the status of the local pod, given the remote one.
 func LocalPodStatus(remote *corev1.PodStatus, translator PodIPTranslator, restarts int32, mutators ...RemotePodStatusMutator) corev1.PodStatus {
 	// Translate the relevant IPs
@@ -217,6 +226,8 @@ func RemotePodSpec(creation bool, local, remote *corev1.PodSpec, mutators ...Rem
 	remote.Containers = local.Containers
 	remote.InitContainers = local.InitContainers
 
+	remote.Resources = local.Resources
+	remote.ResourceClaims = local.ResourceClaims
 	remote.Tolerations = RemoteTolerations(local.Tolerations)
 	remote.Volumes = local.Volumes
 
@@ -269,6 +280,50 @@ func TerminateContainerState(cs *corev1.ContainerStatus, phase corev1.PodPhase, 
 			},
 			Waiting: nil,
 			Running: nil,
+		}
+	}
+}
+
+// CheckDRAClaimStatusesReady returns an error if any ResourceClaimTemplateName
+// entry in the pod spec has not yet been resolved by the local kubelet into a
+// concrete ResourceClaim name in Status.ResourceClaimStatuses. The caller should
+// requeue on non-nil to wait for kubelet population.
+func CheckDRAClaimStatusesReady(pod *corev1.Pod) error {
+	resolved := make(map[string]bool, len(pod.Status.ResourceClaimStatuses))
+	for i := range pod.Status.ResourceClaimStatuses {
+		resolved[pod.Status.ResourceClaimStatuses[i].Name] = true
+	}
+	for i := range pod.Spec.ResourceClaims {
+		rc := &pod.Spec.ResourceClaims[i]
+		if rc.ResourceClaimTemplateName != nil && !resolved[rc.Name] {
+			return fmt.Errorf("waiting for ResourceClaimStatus for pod %q claim alias %q", pod.Name, rc.Name)
+		}
+	}
+	return nil
+}
+
+// DRAClaimRewriteMutator returns a RemotePodSpecMutator that rewrites any
+// ResourceClaimTemplateName entries in pod.Spec.ResourceClaims to the concrete
+// ResourceClaimName created in the local cluster, preventing the remote
+// cluster from expanding the template and creating a divergent claim.
+func DRAClaimRewriteMutator(statuses []corev1.PodResourceClaimStatus) RemotePodSpecMutator {
+	return func(remote *corev1.PodSpec) {
+		resolved := make(map[string]string, len(statuses))
+		for i := range statuses {
+			s := &statuses[i]
+			if s.ResourceClaimName != nil {
+				resolved[s.Name] = *s.ResourceClaimName
+			}
+		}
+
+		for i := range remote.ResourceClaims {
+			rc := &remote.ResourceClaims[i]
+			if rc.ResourceClaimTemplateName != nil {
+				if name, ok := resolved[rc.Name]; ok {
+					rc.ResourceClaimName = &name
+					rc.ResourceClaimTemplateName = nil
+				}
+			}
 		}
 	}
 }

--- a/pkg/virtualKubelet/forge/pods_test.go
+++ b/pkg/virtualKubelet/forge/pods_test.go
@@ -36,6 +36,11 @@ import (
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 )
 
+const (
+	fakeNICValue               = "nic"
+	fakeGarbageFromRemoteValue = "garbage-from-remote"
+)
+
 var _ = Describe("Pod forging", func() {
 	Translator := func(input string) string { return input + "-reflected" }
 	SASecretRetriever := func(input string) string { return input + "-secret" }
@@ -1050,6 +1055,160 @@ var _ = Describe("Pod forging", func() {
 				Expect(output.Memory.UsageBytes).To(PointTo(BeNumerically("==", 10*1e6)))
 				Expect(output.Memory.WorkingSetBytes).To(PointTo(BeNumerically("==", 10*1e6)))
 			})
+		})
+	})
+
+	Describe("the CheckDRAClaimStatusesReady function", func() {
+		var pod *corev1.Pod
+
+		BeforeEach(func() {
+			pod = &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"}}
+		})
+
+		It("should return nil for a pod with no ResourceClaims", func() {
+			Expect(forge.CheckDRAClaimStatusesReady(pod)).To(Succeed())
+		})
+
+		It("should return nil when all references are direct ResourceClaimName", func() {
+			pod.Spec.ResourceClaims = []corev1.PodResourceClaim{
+				{Name: fakeGPUValue, ResourceClaimName: ptr.To("my-claim")},
+				{Name: fakeNICValue, ResourceClaimName: ptr.To("my-claim-2")},
+			}
+			Expect(forge.CheckDRAClaimStatusesReady(pod)).To(Succeed())
+		})
+
+		It("should return nil when every template is matched in Status.ResourceClaimStatuses", func() {
+			pod.Spec.ResourceClaims = []corev1.PodResourceClaim{
+				{Name: fakeGPUValue, ResourceClaimTemplateName: ptr.To("gpu-tpl")},
+			}
+			pod.Status.ResourceClaimStatuses = []corev1.PodResourceClaimStatus{
+				{Name: fakeGPUValue, ResourceClaimName: ptr.To("p-gpu-abc123")},
+			}
+			Expect(forge.CheckDRAClaimStatusesReady(pod)).To(Succeed())
+		})
+
+		It("should return an error when a template has no matching status", func() {
+			pod.Spec.ResourceClaims = []corev1.PodResourceClaim{
+				{Name: fakeGPUValue, ResourceClaimTemplateName: ptr.To("gpu-tpl")},
+			}
+			err := forge.CheckDRAClaimStatusesReady(pod)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fakeGPUValue))
+		})
+
+		It("should return an error when only some of multiple templates are matched", func() {
+			pod.Spec.ResourceClaims = []corev1.PodResourceClaim{
+				{Name: fakeGPUValue, ResourceClaimTemplateName: ptr.To("gpu-tpl")},
+				{Name: fakeNICValue, ResourceClaimTemplateName: ptr.To("nic-tpl")},
+			}
+			pod.Status.ResourceClaimStatuses = []corev1.PodResourceClaimStatus{
+				{Name: fakeGPUValue, ResourceClaimName: ptr.To("p-gpu-abc")},
+			}
+			err := forge.CheckDRAClaimStatusesReady(pod)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fakeNICValue))
+		})
+
+		It("should not flag direct refs even when other templates are unresolved", func() {
+			pod.Spec.ResourceClaims = []corev1.PodResourceClaim{
+				{Name: fakeGPUValue, ResourceClaimName: ptr.To("my-claim")},
+				{Name: fakeNICValue, ResourceClaimTemplateName: ptr.To("nic-tpl")},
+			}
+			err := forge.CheckDRAClaimStatusesReady(pod)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fakeNICValue))
+			Expect(err.Error()).ToNot(ContainSubstring("alias \"" + fakeGPUValue + "\""))
+		})
+	})
+
+	Describe("the DRAClaimRewriteMutator function", func() {
+		It("should leave direct ResourceClaimName references unchanged", func() {
+			spec := &corev1.PodSpec{
+				ResourceClaims: []corev1.PodResourceClaim{
+					{Name: fakeGPUValue, ResourceClaimName: ptr.To("my-claim")},
+				},
+			}
+			forge.DRAClaimRewriteMutator(nil)(spec)
+			Expect(spec.ResourceClaims[0].ResourceClaimName).To(PointTo(Equal("my-claim")))
+			Expect(spec.ResourceClaims[0].ResourceClaimTemplateName).To(BeNil())
+		})
+
+		It("should rewrite a template ref to the resolved ResourceClaimName", func() {
+			spec := &corev1.PodSpec{
+				ResourceClaims: []corev1.PodResourceClaim{
+					{Name: fakeGPUValue, ResourceClaimTemplateName: ptr.To("gpu-tpl")},
+				},
+			}
+			statuses := []corev1.PodResourceClaimStatus{
+				{Name: fakeGPUValue, ResourceClaimName: ptr.To("p-gpu-abc")},
+			}
+			forge.DRAClaimRewriteMutator(statuses)(spec)
+			Expect(spec.ResourceClaims).To(HaveLen(1))
+			Expect(spec.ResourceClaims[0].ResourceClaimName).To(PointTo(Equal("p-gpu-abc")))
+			Expect(spec.ResourceClaims[0].ResourceClaimTemplateName).To(BeNil())
+		})
+
+		It("should rewrite templates while preserving direct refs in a mixed list", func() {
+			spec := &corev1.PodSpec{
+				ResourceClaims: []corev1.PodResourceClaim{
+					{Name: fakeGPUValue, ResourceClaimName: ptr.To("my-claim")},
+					{Name: fakeNICValue, ResourceClaimTemplateName: ptr.To("nic-tpl")},
+				},
+			}
+			statuses := []corev1.PodResourceClaimStatus{
+				{Name: fakeNICValue, ResourceClaimName: ptr.To("p-nic-xyz")},
+			}
+			forge.DRAClaimRewriteMutator(statuses)(spec)
+			Expect(spec.ResourceClaims).To(HaveLen(2))
+			Expect(spec.ResourceClaims[0].ResourceClaimName).To(PointTo(Equal("my-claim")))
+			Expect(spec.ResourceClaims[0].ResourceClaimTemplateName).To(BeNil())
+			Expect(spec.ResourceClaims[1].ResourceClaimName).To(PointTo(Equal("p-nic-xyz")))
+			Expect(spec.ResourceClaims[1].ResourceClaimTemplateName).To(BeNil())
+		})
+	})
+
+	Describe("the PreserveResourceClaimStatusesMutator function", func() {
+		It("should overwrite remote ResourceClaimStatuses with the local ones", func() {
+			localStatuses := []corev1.PodResourceClaimStatus{
+				{Name: fakeGPUValue, ResourceClaimName: ptr.To("p-gpu")},
+			}
+			remoteStatus := &corev1.PodStatus{
+				ResourceClaimStatuses: []corev1.PodResourceClaimStatus{
+					{Name: fakeGarbageFromRemoteValue},
+				},
+			}
+			forge.PreserveResourceClaimStatusesMutator(localStatuses)(remoteStatus)
+			Expect(remoteStatus.ResourceClaimStatuses).To(Equal(localStatuses))
+		})
+
+		It("should clear remote ResourceClaimStatuses", func() {
+			remoteStatus := &corev1.PodStatus{
+				ResourceClaimStatuses: []corev1.PodResourceClaimStatus{
+					{Name: fakeGarbageFromRemoteValue},
+				},
+			}
+			forge.PreserveResourceClaimStatusesMutator(nil)(remoteStatus)
+			Expect(remoteStatus.ResourceClaimStatuses).To(BeNil())
+		})
+	})
+
+	Describe("the RemotePodSpec function (DRA ResourceClaims propagation)", func() {
+		It("should copy local.ResourceClaims into the freshly forged remote spec", func() {
+			local := &corev1.PodSpec{
+				ResourceClaims: []corev1.PodResourceClaim{
+					{Name: fakeGPUValue, ResourceClaimName: ptr.To("my-claim")},
+				},
+			}
+			remote := &corev1.PodSpec{}
+			out := forge.RemotePodSpec(true /* creation */, local, remote)
+			Expect(out.ResourceClaims).To(HaveLen(1))
+			Expect(out.ResourceClaims[0].Name).To(Equal(fakeGPUValue))
+			Expect(out.ResourceClaims[0].ResourceClaimName).To(PointTo(Equal("my-claim")))
+		})
+
+		It("should leave the remote spec ResourceClaims nil when local has none", func() {
+			out := forge.RemotePodSpec(true, &corev1.PodSpec{}, &corev1.PodSpec{})
+			Expect(out.ResourceClaims).To(BeNil())
 		})
 	})
 })

--- a/pkg/virtualKubelet/provider/provider.go
+++ b/pkg/virtualKubelet/provider/provider.go
@@ -37,6 +37,7 @@ import (
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/configuration"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/dra"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/event"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/exposition"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/manager"
@@ -154,6 +155,20 @@ func NewLiqoProvider(ctx context.Context, cfg *InitConfig, eb record.EventBroadc
 
 	if !cfg.DisableIPReflection {
 		reflectionManager.With(exposition.NewEndpointSliceReflector(cfg.LocalPodCIDRs, ptr.To(cfg.ReflectorsConfigs[resources.EndpointSlice])))
+	}
+
+	draSupported, err := dra.IsDRASupportedOnBothClusters(localClient, remoteClient)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to check whether DRA is supported")
+	}
+	if draSupported {
+		klog.Infof("DRA support detected on both clusters: registering DRA reflectors")
+		reflectionManager.
+			With(dra.NewResourceSliceReflector(localClient, remoteClient, cfg.InformerResyncPeriod,
+				ptr.To(cfg.ReflectorsConfigs[resources.ResourceSlice]))).
+			With(dra.NewResourceClaimReflector(ptr.To(cfg.ReflectorsConfigs[resources.ResourceClaim])))
+	} else {
+		klog.Info("DRA support is not enabled: resource.k8s.io/v1 is not available on local and/or remote cluster")
 	}
 
 	reflectionManager.Start(ctx)

--- a/pkg/virtualKubelet/reflection/dra/checks.go
+++ b/pkg/virtualKubelet/reflection/dra/checks.go
@@ -1,0 +1,63 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dra
+
+import (
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
+)
+
+// draAPIGroupVersion is the API group/version for Kubernetes Dynamic Resource
+// Allocation. Reflectors are only registered when both clusters expose this group.
+const draAPIGroupVersion = "resource.k8s.io/v1"
+
+// IsDRASupportedOnBothClusters returns true only when resource.k8s.io/v1 (with the
+// resourceslices, resourceclaims and deviceclasses resources) is available on both the
+// local and the remote cluster.
+func IsDRASupportedOnBothClusters(local, remote kubernetes.Interface) (bool, error) {
+	okLocal, err := isDRAAPISupported(local)
+	if err != nil {
+		return false, err
+	}
+	if !okLocal {
+		return false, nil
+	}
+	return isDRAAPISupported(remote)
+}
+
+func isDRAAPISupported(client kubernetes.Interface) (bool, error) {
+	res, err := client.Discovery().ServerResourcesForGroupVersion(draAPIGroupVersion)
+	if err != nil {
+		if discovery.IsGroupDiscoveryFailedError(err) || kerrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	present := map[string]bool{
+		"resourceslices": false,
+		"resourceclaims": false,
+		"deviceclasses":  false,
+	}
+	for i := range res.APIResources {
+		present[res.APIResources[i].Name] = true
+	}
+	for _, ok := range present {
+		if !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/pkg/virtualKubelet/reflection/dra/checks_test.go
+++ b/pkg/virtualKubelet/reflection/dra/checks_test.go
@@ -1,0 +1,141 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dra_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/dra"
+)
+
+const (
+	fakeResourceK8sIOV1 = "resource.k8s.io/v1"
+	fakeDeviceClasses   = "deviceclasses"
+)
+
+var _ = Describe("DRA support detection", func() {
+
+	// allDRAResources returns a fully-populated APIResourceList for resource.k8s.io/v1.
+	allDRAResources := func() *metav1.APIResourceList {
+		return &metav1.APIResourceList{
+			GroupVersion: fakeResourceK8sIOV1,
+			APIResources: []metav1.APIResource{
+				{Name: "resourceslices", Namespaced: false},
+				{Name: "resourceclaims", Namespaced: true},
+				{Name: fakeDeviceClasses, Namespaced: false},
+			},
+		}
+	}
+
+	withResources := func(resources ...*metav1.APIResourceList) *fake.Clientset {
+		fakeClient := fake.NewClientset()
+		fakeClient.Discovery().(*discoveryfake.FakeDiscovery).Resources = resources
+		return fakeClient
+	}
+
+	Describe("isDRAAPISupported", func() {
+		It("should return true when all three DRA resources are exposed", func() {
+			c := withResources(allDRAResources())
+			ok, err := dra.IsDRAAPISupported(c)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		DescribeTable("should return false when any of the three required resources is missing",
+			func(missing string) {
+				rl := allDRAResources()
+				kept := rl.APIResources[:0]
+				for _, r := range rl.APIResources {
+					if r.Name != missing {
+						kept = append(kept, r)
+					}
+				}
+				rl.APIResources = kept
+				c := withResources(rl)
+
+				ok, err := dra.IsDRAAPISupported(c)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			},
+			Entry("missing resourceslices", "resourceslices"),
+			Entry("missing resourceclaims", "resourceclaims"),
+			Entry("missing deviceclasses", "deviceclasses"),
+		)
+
+		It("should return false when the resource.k8s.io/v1 group is not exposed at all", func() {
+			c := withResources()
+			ok, err := dra.IsDRAAPISupported(c)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+
+		It("should return false when APIResources is empty for the group", func() {
+			c := withResources(&metav1.APIResourceList{
+				GroupVersion: fakeResourceK8sIOV1,
+				APIResources: []metav1.APIResource{},
+			})
+			ok, err := dra.IsDRAAPISupported(c)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+
+		It("should propagate an unexpected discovery error", func() {
+			c := fake.NewClientset()
+			err := errors.New("boom")
+			c.Discovery().(*discoveryfake.FakeDiscovery).PrependReactor("get", "resource",
+				func(_ clienttesting.Action) (bool, runtime.Object, error) {
+					return true, nil, err
+				},
+			)
+			ok, err := dra.IsDRAAPISupported(c)
+			Expect(err).To(MatchError(err))
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Describe("IsDRASupportedOnBothClusters", func() {
+		It("should return true when both clusters expose DRA", func() {
+			local := withResources(allDRAResources())
+			remote := withResources(allDRAResources())
+			ok, err := dra.IsDRASupportedOnBothClusters(local, remote)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should return false when local supports DRA but remote does not", func() {
+			local := withResources(allDRAResources())
+			remote := withResources()
+			ok, err := dra.IsDRASupportedOnBothClusters(local, remote)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+
+		It("should return false when remote supports DRA but local does not", func() {
+			local := withResources()
+			remote := withResources(allDRAResources())
+			ok, err := dra.IsDRASupportedOnBothClusters(local, remote)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+	})
+})

--- a/pkg/virtualKubelet/reflection/dra/deviceclass.go
+++ b/pkg/virtualKubelet/reflection/dra/deviceclass.go
@@ -1,0 +1,64 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dra
+
+import (
+	"context"
+	"fmt"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	resourcev1clients "k8s.io/client-go/kubernetes/typed/resource/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
+)
+
+// ensureRemoteDeviceClass copies a DeviceClass from local to remote when missing on the
+// remote cluster. It returns nil if the class already exists or was successfully created;
+// it returns an error if the local class is missing or if the remote create failed for
+// reasons other than AlreadyExists.
+//
+// Per design, reflected DeviceClasses are never garbage-collected: once present on the
+// remote, they remain.
+func ensureRemoteDeviceClass(
+	ctx context.Context,
+	name string,
+	localClient, remoteClient resourcev1clients.DeviceClassInterface,
+	labelsNotReflected, annotationsNotReflected []string,
+) error {
+	_, err := remoteClient.Get(ctx, name, metav1.GetOptions{})
+	switch {
+	case err == nil:
+		return nil
+	case !kerrors.IsNotFound(err):
+		return fmt.Errorf("getting remote DeviceClass %q: %w", name, err)
+	}
+
+	local, err := localClient.Get(ctx, name, metav1.GetOptions{})
+	switch {
+	case kerrors.IsNotFound(err):
+		return fmt.Errorf("cannot reflect DeviceClass %q that does not exist locally: %w", name, err)
+	case err != nil:
+		return fmt.Errorf("getting local DeviceClass %q: %w", name, err)
+	}
+
+	remote := forge.RemoteDeviceClass(local, labelsNotReflected, annotationsNotReflected)
+	if _, err := remoteClient.Create(ctx, remote, metav1.CreateOptions{}); err != nil && !kerrors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating remote DeviceClass %q: %w", name, err)
+	}
+	klog.Infof("Reflected DeviceClass %q to remote cluster", name)
+	return nil
+}

--- a/pkg/virtualKubelet/reflection/dra/deviceclass_test.go
+++ b/pkg/virtualKubelet/reflection/dra/deviceclass_test.go
@@ -1,0 +1,196 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dra_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	resourcev1 "k8s.io/api/resource/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/dra"
+)
+
+var _ = Describe("ensureRemoteDeviceClass", func() {
+	const (
+		className           = "gpu-class"
+		deviceClassResource = "deviceclasses"
+	)
+
+	var (
+		localClient, remoteClient *fake.Clientset
+		opts                      *forge.ForgingOpts
+	)
+
+	BeforeEach(func() {
+		localClient = fake.NewClientset()
+		remoteClient = fake.NewClientset()
+		opts = testutil.FakeForgingOpts()
+	})
+
+	ensureDeviceClass := func() error {
+		return dra.EnsureRemoteDeviceClass(ctx, className,
+			localClient.ResourceV1().DeviceClasses(),
+			remoteClient.ResourceV1().DeviceClasses(),
+			opts.LabelsNotReflected, opts.AnnotationsNotReflected)
+	}
+
+	When("the remote DeviceClass already exists", func() {
+		var createCount int
+
+		BeforeEach(func() {
+			_, err := remoteClient.ResourceV1().DeviceClasses().Create(ctx, &resourcev1.DeviceClass{
+				ObjectMeta: metav1.ObjectMeta{Name: className},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			createCount = 0
+			remoteClient.PrependReactor("create", deviceClassResource,
+				func(_ clienttesting.Action) (bool, runtime.Object, error) {
+					createCount++
+					return false, nil, nil
+				},
+			)
+		})
+
+		It("should return nil and not issue any Create on the remote", func() {
+			Expect(ensureDeviceClass()).To(Succeed())
+			Expect(createCount).To(Equal(0))
+		})
+	})
+
+	When("the remote is missing and the local DeviceClass exists", func() {
+		BeforeEach(func() {
+			_, err := localClient.ResourceV1().DeviceClasses().Create(ctx, &resourcev1.DeviceClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: className,
+					Labels: map[string]string{
+						fooVal:                            barVal,
+						testutil.FakeNotReflectedLabelKey: trueVal,
+					},
+					Annotations: map[string]string{
+						testutil.FakeNotReflectedAnnotKey: trueVal,
+					},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should create the remote with reflection labels and filtered keys", func() {
+			Expect(ensureDeviceClass()).To(Succeed())
+
+			remote, err := remoteClient.ResourceV1().DeviceClasses().Get(ctx, className, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(remote.Labels).To(HaveKeyWithValue(fooVal, barVal))
+			Expect(remote.Labels).To(HaveKeyWithValue(forge.LiqoOriginClusterIDKey, LocalClusterID))
+			Expect(remote.Labels).To(HaveKeyWithValue(forge.LiqoDestinationClusterIDKey, RemoteClusterID))
+			Expect(remote.Labels).ToNot(HaveKey(testutil.FakeNotReflectedLabelKey))
+			Expect(remote.Annotations).ToNot(HaveKey(testutil.FakeNotReflectedAnnotKey))
+		})
+	})
+
+	When("both remote and local are missing", func() {
+		It("should return a NotFound error mentioning that the local class does not exist", func() {
+			err := ensureDeviceClass()
+			Expect(err).To(HaveOccurred())
+			Expect(kerrors.IsNotFound(err)).To(BeTrue(),
+				"the error chain must surface NotFound so callers can soft-skip via kerrors.IsNotFound")
+			Expect(err.Error()).To(ContainSubstring("cannot reflect DeviceClass"))
+		})
+	})
+
+	When("the remote Get returns a transient error", func() {
+		BeforeEach(func() {
+			remoteClient.PrependReactor("get", deviceClassResource,
+				func(_ clienttesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("remote boom")
+				},
+			)
+		})
+		It("should propagate the error wrapped with a 'getting remote DeviceClass' prefix", func() {
+			err := ensureDeviceClass()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("getting remote DeviceClass"))
+			Expect(err.Error()).To(ContainSubstring("remote boom"))
+		})
+	})
+
+	When("the local Get returns a transient error", func() {
+		BeforeEach(func() {
+			// Remote not present so the function moves on to fetch the local.
+			localClient.PrependReactor("get", deviceClassResource,
+				func(_ clienttesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("local boom")
+				},
+			)
+		})
+		It("should propagate the error wrapped with a 'getting local DeviceClass' prefix", func() {
+			err := ensureDeviceClass()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("getting local DeviceClass"))
+			Expect(err.Error()).To(ContainSubstring("local boom"))
+		})
+	})
+
+	When("the remote Create returns AlreadyExists (concurrent create)", func() {
+		BeforeEach(func() {
+			_, err := localClient.ResourceV1().DeviceClasses().Create(ctx, &resourcev1.DeviceClass{
+				ObjectMeta: metav1.ObjectMeta{Name: className},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			remoteClient.PrependReactor("create", deviceClassResource,
+				func(_ clienttesting.Action) (bool, runtime.Object, error) {
+					return true, nil, kerrors.NewAlreadyExists(schema.GroupResource{
+						Group: "resource.k8s.io", Resource: deviceClassResource,
+					}, className)
+				},
+			)
+		})
+		It("should swallow the error and report success", func() {
+			Expect(ensureDeviceClass()).To(Succeed())
+		})
+	})
+
+	When("the remote Create returns an unexpected error", func() {
+		BeforeEach(func() {
+			_, err := localClient.ResourceV1().DeviceClasses().Create(ctx, &resourcev1.DeviceClass{
+				ObjectMeta: metav1.ObjectMeta{Name: className},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			remoteClient.PrependReactor("create", deviceClassResource,
+				func(_ clienttesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("boom while creating")
+				},
+			)
+		})
+		It("should propagate the error wrapped with a 'creating remote DeviceClass' prefix", func() {
+			err := ensureDeviceClass()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("creating remote DeviceClass"))
+			Expect(err.Error()).To(ContainSubstring("boom while creating"))
+		})
+	})
+})

--- a/pkg/virtualKubelet/reflection/dra/doc.go
+++ b/pkg/virtualKubelet/reflection/dra/doc.go
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package remoteclusterwide defines the ClusterRole containing the permissions required by the virtual kubelet in the remote cluster.
-package remoteclusterwide
-
-// +kubebuilder:rbac:groups=metrics.liqo.io,resources=scrape/metrics,verbs=get;list;watch
-// +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
-
-// Permissions for DRA reflection of ResourceSlices.
-// +kubebuilder:rbac:groups=resource.k8s.io,resources=resourceslices,verbs=get;list;watch
-// +kubebuilder:rbac:groups=resource.k8s.io,resources=deviceclasses,verbs=get;list;watch;create
+// Package dra provides Dynamic Resource Allocation (DRA) support detection and reflection utilities
+// for the Liqo virtual kubelet.
+package dra

--- a/pkg/virtualKubelet/reflection/dra/dra_suite_test.go
+++ b/pkg/virtualKubelet/reflection/dra/dra_suite_test.go
@@ -1,0 +1,101 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dra_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
+)
+
+const (
+	LocalNamespace  = "local-namespace"
+	RemoteNamespace = "remote-namespace"
+
+	LocalClusterID  = "local-cluster-id"
+	RemoteClusterID = "remote-cluster-id"
+
+	LiqoNodeName = "local-node"
+	LiqoNodeIP   = "1.1.1.1"
+	LiqoNodeUID  = types.UID("liqo-node-uid")
+
+	// Shared test constants used across DRA test files.
+	barVal         = "bar"
+	fooVal         = "foo"
+	trueVal        = "true"
+	fakeClaimName  = "req-1"
+	fakeDriverName = "test.driver"
+	fakePoolName   = "pool"
+)
+
+var (
+	// Per-test fake clients. Recreated in BeforeEach so tests are isolated.
+	localClient, remoteClient *fake.Clientset
+
+	ctx    context.Context
+	cancel context.CancelFunc
+)
+
+func TestDRA(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DRA Reflection Suite")
+}
+
+var _ = BeforeSuite(func() {
+	testutil.LogsToGinkgoWriter()
+	forge.Init(LocalClusterID, RemoteClusterID, LiqoNodeName, LiqoNodeIP)
+})
+
+var _ = BeforeEach(func() {
+	ctx, cancel = context.WithCancel(context.Background())
+
+	// Local cluster preloaded with the virtual node so OwnerReference resolution
+	// works without each test having to recreate it.
+	localClient = fake.NewClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: LiqoNodeName,
+			UID:  LiqoNodeUID,
+			Labels: map[string]string{
+				corev1.LabelHostname: LiqoNodeName,
+				consts.TypeLabel:     consts.TypeNode,
+			},
+		},
+	})
+	remoteClient = fake.NewClientset()
+})
+
+var _ = AfterEach(func() { cancel() })
+
+// FakeEventHandler is a no-op handler factory used to bypass real informer
+// event-handler wiring in tests.
+var FakeEventHandler = func(options.Keyer, ...options.EventFilter) cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(_ interface{}) {},
+		UpdateFunc: func(_, _ interface{}) {},
+		DeleteFunc: func(_ interface{}) {},
+	}
+}

--- a/pkg/virtualKubelet/reflection/dra/export_test.go
+++ b/pkg/virtualKubelet/reflection/dra/export_test.go
@@ -1,0 +1,74 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dra
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	resourcev1listers "k8s.io/client-go/listers/resource/v1"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
+)
+
+// Test-only exports for private members of the dra package.
+
+// Handle exposes ResourceSliceReflector.handle for tests.
+var Handle = (*ResourceSliceReflector).handle
+
+// EnqueueRemoteSlicesForNode exposes ResourceSliceReflector.enqueueRemoteSlicesForNode for tests.
+var EnqueueRemoteSlicesForNode = (*ResourceSliceReflector).enqueueRemoteSlicesForNode
+
+// EnsureRemoteDeviceClass exposes the package-private function for tests.
+var EnsureRemoteDeviceClass = ensureRemoteDeviceClass
+
+// IsDRAAPISupported exposes the package-private discovery probe for tests.
+var IsDRAAPISupported = isDRAAPISupported
+
+// NewResourceSliceReflectorForTest builds a ResourceSliceReflector with prebuilt
+// listers and clients, bypassing the informer factory wiring done by Start.
+func NewResourceSliceReflectorForTest(
+	localClient, remoteClient kubernetes.Interface,
+	localSlices, remoteSlices resourcev1listers.ResourceSliceLister,
+	localNodes corev1listers.NodeLister,
+	forgingOpts *forge.ForgingOpts,
+) *ResourceSliceReflector {
+	return &ResourceSliceReflector{
+		name:         ResourceSliceReflectorName,
+		workers:      1,
+		localClient:  localClient,
+		remoteClient: remoteClient,
+		localSlices:  localSlices,
+		remoteSlices: remoteSlices,
+		localNodes:   localNodes,
+		forgingOpts:  forgingOpts,
+		workqueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[types.NamespacedName](),
+			workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{Name: ResourceSliceReflectorName}),
+	}
+}
+
+// SetForgingOpts mutates the forging options on a reflector after construction.
+// Used by tests to swap the opts mid-suite.
+func (rsr *ResourceSliceReflector) SetForgingOpts(forgingOpts *forge.ForgingOpts) {
+	rsr.forgingOpts = forgingOpts
+}
+
+// WorkqueueLen returns the number of items currently queued. Test-only helper
+// so suites can assert on enqueue/resync behavior.
+func (rsr *ResourceSliceReflector) WorkqueueLen() int {
+	return rsr.workqueue.Len()
+}

--- a/pkg/virtualKubelet/reflection/dra/resourceclaim.go
+++ b/pkg/virtualKubelet/reflection/dra/resourceclaim.go
@@ -1,0 +1,201 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dra
+
+import (
+	"context"
+	"fmt"
+
+	resourcev1 "k8s.io/api/resource/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	resourcev1clients "k8s.io/client-go/kubernetes/typed/resource/v1"
+	resourcev1listers "k8s.io/client-go/listers/resource/v1"
+	"k8s.io/klog/v2"
+
+	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
+	"github.com/liqotech/liqo/pkg/utils/virtualkubelet"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/generic"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/manager"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
+)
+
+const (
+	// ResourceClaimReflectorName is the name associated with the ResourceClaim reflector.
+	ResourceClaimReflectorName = "ResourceClaim"
+)
+
+// ResourceClaimReflector mirrors ResourceClaim objects from the local cluster to the
+// remote cluster. The lifecycle of a remote claim is anchored to the local claim: a
+// remote claim is deleted only when its local counterpart is deleted.
+type ResourceClaimReflector struct {
+	manager.Reflector
+}
+
+// NamespacedResourceClaimReflector handles ResourceClaim reflection for a single
+// (local, remote) namespace pair.
+type NamespacedResourceClaimReflector struct {
+	generic.NamespacedReflector
+
+	localClaims  resourcev1listers.ResourceClaimNamespaceLister
+	remoteClaims resourcev1listers.ResourceClaimNamespaceLister
+
+	remoteClaimsClient        resourcev1clients.ResourceClaimInterface
+	localDeviceClassesClient  resourcev1clients.DeviceClassInterface
+	remoteDeviceClassesClient resourcev1clients.DeviceClassInterface
+}
+
+var _ manager.NamespacedReflector = (*NamespacedResourceClaimReflector)(nil)
+
+// NewResourceClaimReflector returns a new ResourceClaimReflector.
+func NewResourceClaimReflector(reflectorConfig *offloadingv1beta1.ReflectorConfig) manager.Reflector {
+	r := &ResourceClaimReflector{}
+	r.Reflector = generic.NewReflector(ResourceClaimReflectorName,
+		r.NewNamespaced, generic.WithoutFallback(),
+		reflectorConfig.NumWorkers, offloadingv1beta1.CustomLiqo, generic.ConcurrencyModeAll)
+	return r
+}
+
+// NewNamespaced returns a new NamespacedResourceClaimReflector instance.
+func (rcr *ResourceClaimReflector) NewNamespaced(opts *options.NamespacedOpts) manager.NamespacedReflector {
+	localClaims := opts.LocalFactory.Resource().V1().ResourceClaims()
+	remoteClaims := opts.RemoteFactory.Resource().V1().ResourceClaims()
+
+	// Local claim events enqueue the claim name directly.
+	_, err := localClaims.Informer().AddEventHandler(opts.HandlerFactory(generic.NamespacedKeyer(opts.LocalNamespace)))
+	utilruntime.Must(err)
+	// Remote claim events enqueue by name (preserved during reflection).
+	_, err = remoteClaims.Informer().AddEventHandler(opts.HandlerFactory(
+		func(obj metav1.Object) []types.NamespacedName {
+			if !forge.IsReflected(obj) {
+				return nil
+			}
+			return []types.NamespacedName{{Namespace: opts.LocalNamespace, Name: obj.GetName()}}
+		},
+	))
+	utilruntime.Must(err)
+
+	return &NamespacedResourceClaimReflector{
+		NamespacedReflector: generic.NewNamespacedReflector(opts, ResourceClaimReflectorName),
+
+		localClaims:  localClaims.Lister().ResourceClaims(opts.LocalNamespace),
+		remoteClaims: remoteClaims.Lister().ResourceClaims(opts.RemoteNamespace),
+
+		remoteClaimsClient:        opts.RemoteClient.ResourceV1().ResourceClaims(opts.RemoteNamespace),
+		localDeviceClassesClient:  opts.LocalClient.ResourceV1().DeviceClasses(),
+		remoteDeviceClassesClient: opts.RemoteClient.ResourceV1().DeviceClasses(),
+	}
+}
+
+// Handle reconciles a single ResourceClaim identified by claimName.
+// The remote claim lifecycle is anchored to the local claim: the remote is
+// deleted only when the local claim no longer exists.
+func (n *NamespacedResourceClaimReflector) Handle(ctx context.Context, claimName string) error {
+	klog.V(4).Infof("Handling ResourceClaim reflection for local claim %q", n.LocalRef(claimName))
+
+	local, lerr := n.localClaims.Get(claimName)
+	if lerr != nil && !kerrors.IsNotFound(lerr) {
+		return lerr
+	}
+
+	remote, rerr := n.remoteClaims.Get(claimName)
+	if rerr != nil && !kerrors.IsNotFound(rerr) {
+		return rerr
+	}
+
+	if remote == nil && local == nil {
+		// No local and no remote: nothing to do.
+		return nil
+	}
+
+	// Refuse to mutate a remote claim we don't own.
+	if rerr == nil && !forge.IsReflected(remote) {
+		klog.Infof("Skipping reflection of ResourceClaim %q: remote exists and is not managed by Liqo", n.RemoteRef(claimName))
+		return nil
+	}
+
+	// Local claim gone: clean up the remote if we own it.
+	if kerrors.IsNotFound(lerr) && remote != nil {
+		klog.Infof("Deleting remote ResourceClaim %q: local no longer exists", n.RemoteRef(claimName))
+		return n.DeleteRemote(ctx, n.remoteClaimsClient, ResourceClaimReflectorName, claimName, remote.GetUID())
+	}
+
+	// Ensure every DeviceClass referenced by the claim is present on the remote.
+	for _, dc := range forge.ReferencedDeviceClasses(local) {
+		err := ensureRemoteDeviceClass(ctx, dc,
+			n.localDeviceClassesClient, n.remoteDeviceClassesClient,
+			n.ForgingOpts.LabelsNotReflected, n.ForgingOpts.AnnotationsNotReflected)
+		switch {
+		case kerrors.IsNotFound(err):
+			// Do not reflect the claim if any referenced class is missing locally.
+			klog.Warningf("Skipping reflection of ResourceClaim %q as it references missing local DeviceClass %q", n.LocalRef(claimName), dc)
+			return nil
+		case err != nil:
+			return fmt.Errorf("ensuring ResourceClaim %q DeviceClass: %w", claimName, err)
+		}
+	}
+
+	desired := forge.RemoteResourceClaim(local, n.RemoteNamespace(),
+		n.ForgingOpts.LabelsNotReflected, n.ForgingOpts.AnnotationsNotReflected)
+
+	if kerrors.IsNotFound(rerr) {
+		if _, err := n.remoteClaimsClient.Create(ctx, desired, metav1.CreateOptions{}); err != nil && !kerrors.IsAlreadyExists(err) {
+			klog.Errorf("Failed to create remote ResourceClaim %q: %v", n.RemoteRef(claimName), err)
+			return fmt.Errorf("creating ResourceClaim %q: %w", n.RemoteRef(claimName), err)
+		}
+		klog.Infof("Remote ResourceClaim %q successfully created", n.RemoteRef(claimName))
+		return nil
+	}
+
+	// ResourceClaim.Spec is immutable; only labels/annotations can be updated.
+	if apiequality.Semantic.DeepEqual(remote.Labels, desired.Labels) &&
+		apiequality.Semantic.DeepEqual(remote.Annotations, desired.Annotations) {
+		klog.V(4).Infof("Remote ResourceClaim %q is already up-to-date", n.RemoteRef(claimName))
+		return nil
+	}
+	updated := remote.DeepCopy()
+	updated.Labels = desired.Labels
+	updated.Annotations = desired.Annotations
+	if _, err := n.remoteClaimsClient.Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		klog.Errorf("Failed to update remote ResourceClaim %q metadata: %v", n.RemoteRef(claimName), err)
+		return fmt.Errorf("updating ResourceClaim %q: %w", n.RemoteRef(claimName), err)
+	}
+	return nil
+}
+
+// List returns the union of local and remote reflected claim names so that resync
+// catches orphaned remote claims whose local was deleted while the VK was down.
+func (n *NamespacedResourceClaimReflector) List() ([]any, error) {
+	local, lerr := virtualkubelet.List[virtualkubelet.Lister[*resourcev1.ResourceClaim]](
+		n.localClaims,
+	)
+
+	if lerr != nil {
+		return nil, fmt.Errorf("listing local ResourceClaims: %w", lerr)
+	}
+
+	remote, rerr := virtualkubelet.List[virtualkubelet.Lister[*resourcev1.ResourceClaim]](
+		n.remoteClaims,
+	)
+	if rerr != nil {
+		return nil, fmt.Errorf("listing remote ResourceClaims: %w", rerr)
+	}
+
+	return append(local, remote...), nil
+}

--- a/pkg/virtualKubelet/reflection/dra/resourceclaim_test.go
+++ b/pkg/virtualKubelet/reflection/dra/resourceclaim_test.go
@@ -1,0 +1,350 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dra_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	resourcev1 "k8s.io/api/resource/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/trace"
+
+	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/dra"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/manager"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
+)
+
+var _ = Describe("NamespacedResourceClaimReflector", func() {
+	const (
+		claimName       = "claim-1"
+		deviceClassName = "gpu-class"
+	)
+
+	var (
+		reflector manager.NamespacedReflector
+		err       error
+	)
+
+	createLocalClaim := func(c *resourcev1.ResourceClaim) *resourcev1.ResourceClaim {
+		c.Namespace = LocalNamespace
+		out, e := localClient.ResourceV1().ResourceClaims(LocalNamespace).Create(ctx, c, metav1.CreateOptions{})
+		Expect(e).ToNot(HaveOccurred())
+		return out
+	}
+	createRemoteClaim := func(c *resourcev1.ResourceClaim) *resourcev1.ResourceClaim {
+		c.Namespace = RemoteNamespace
+		out, e := remoteClient.ResourceV1().ResourceClaims(RemoteNamespace).Create(ctx, c, metav1.CreateOptions{})
+		Expect(e).ToNot(HaveOccurred())
+		return out
+	}
+	createLocalDeviceClass := func(name string) {
+		_, e := localClient.ResourceV1().DeviceClasses().Create(ctx, &resourcev1.DeviceClass{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		}, metav1.CreateOptions{})
+		Expect(e).ToNot(HaveOccurred())
+	}
+	createRemoteDeviceClass := func(name string) *resourcev1.DeviceClass {
+		out, e := remoteClient.ResourceV1().DeviceClasses().Create(ctx, &resourcev1.DeviceClass{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		}, metav1.CreateOptions{})
+		Expect(e).ToNot(HaveOccurred())
+		return out
+	}
+
+	mkBasicLocalClaim := func() *resourcev1.ResourceClaim {
+		return &resourcev1.ResourceClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: claimName,
+				Labels: map[string]string{
+					fooVal:                            barVal,
+					testutil.FakeNotReflectedLabelKey: trueVal,
+				},
+			},
+			Spec: resourcev1.ResourceClaimSpec{
+				Devices: resourcev1.DeviceClaim{
+					Requests: []resourcev1.DeviceRequest{{
+						Name:    fakeClaimName,
+						Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: deviceClassName, Count: 1},
+					}},
+				},
+			},
+		}
+	}
+
+	JustBeforeEach(func() {
+		localFactory := informers.NewSharedInformerFactory(localClient, 10*time.Hour)
+		remoteFactory := informers.NewSharedInformerFactory(remoteClient, 10*time.Hour)
+		cfg := offloadingv1beta1.ReflectorConfig{
+			NumWorkers: 0,
+			Type:       offloadingv1beta1.CustomLiqo,
+		}
+		rfl := dra.NewResourceClaimReflector(&cfg).(*dra.ResourceClaimReflector)
+		rfl.Start(ctx, options.New(localClient, localFactory.Core().V1().Pods()))
+		reflector = rfl.NewNamespaced(options.NewNamespaced().
+			WithLocal(LocalNamespace, localClient, localFactory).
+			WithRemote(RemoteNamespace, remoteClient, remoteFactory).
+			WithHandlerFactory(FakeEventHandler).
+			WithEventBroadcaster(record.NewBroadcaster()).
+			WithReflectionType(offloadingv1beta1.CustomLiqo).
+			WithForgingOpts(testutil.FakeForgingOpts()))
+
+		localFactory.Start(ctx.Done())
+		remoteFactory.Start(ctx.Done())
+		localFactory.WaitForCacheSync(ctx.Done())
+		remoteFactory.WaitForCacheSync(ctx.Done())
+
+		err = reflector.Handle(trace.ContextWithTrace(ctx, trace.New("ResourceClaim")), claimName)
+	})
+
+	Describe("Handle", func() {
+		Context("when both local and remote claims are missing", func() {
+			It("should be a no-op and return nil", func() {
+				Expect(err).ToNot(HaveOccurred())
+				_, gerr := remoteClient.ResourceV1().ResourceClaims(RemoteNamespace).Get(ctx, claimName, metav1.GetOptions{})
+				Expect(kerrors.IsNotFound(gerr)).To(BeTrue())
+			})
+		})
+
+		Context("when the local exists and the remote does not", func() {
+			Context("with a referenced DeviceClass that exists locally and is missing remotely", func() {
+				BeforeEach(func() {
+					createLocalDeviceClass(deviceClassName)
+					createLocalClaim(mkBasicLocalClaim())
+				})
+
+				It("should reflect the DeviceClass to remote with reflection labels and create the remote claim", func() {
+					Expect(err).ToNot(HaveOccurred())
+
+					dc, gerr := remoteClient.ResourceV1().DeviceClasses().Get(ctx, deviceClassName, metav1.GetOptions{})
+					Expect(gerr).ToNot(HaveOccurred())
+					Expect(forge.IsReflected(dc)).To(BeTrue())
+
+					rc, gerr := remoteClient.ResourceV1().ResourceClaims(RemoteNamespace).Get(ctx, claimName, metav1.GetOptions{})
+					Expect(gerr).ToNot(HaveOccurred())
+					Expect(rc.Labels).To(HaveKeyWithValue(fooVal, barVal))
+					Expect(rc.Labels).ToNot(HaveKey(testutil.FakeNotReflectedLabelKey))
+					Expect(rc.Labels).To(HaveKeyWithValue(forge.LiqoOriginClusterIDKey, LocalClusterID))
+					Expect(rc.Labels).To(HaveKeyWithValue(forge.LiqoDestinationClusterIDKey, RemoteClusterID))
+				})
+			})
+
+			Context("with a referenced DeviceClass that is missing locally", func() {
+				BeforeEach(func() { createLocalClaim(mkBasicLocalClaim()) })
+
+				It("should skip the claim (no remote claim created) and not return an error", func() {
+					// Implementation translates the local-not-found to a soft skip + warning.
+					Expect(err).ToNot(HaveOccurred())
+					_, gerr := remoteClient.ResourceV1().ResourceClaims(RemoteNamespace).Get(ctx, claimName, metav1.GetOptions{})
+					Expect(kerrors.IsNotFound(gerr)).To(BeTrue())
+				})
+			})
+
+			Context("with the referenced DeviceClass already present remotely", func() {
+				var initialDCResourceVersion string
+
+				BeforeEach(func() {
+					createLocalDeviceClass(deviceClassName)
+					existing := createRemoteDeviceClass(deviceClassName)
+					initialDCResourceVersion = existing.ResourceVersion
+					createLocalClaim(mkBasicLocalClaim())
+				})
+
+				It("should not re-create the DeviceClass remotely (resourceVersion preserved)", func() {
+					Expect(err).ToNot(HaveOccurred())
+					dc, gerr := remoteClient.ResourceV1().DeviceClasses().Get(ctx, deviceClassName, metav1.GetOptions{})
+					Expect(gerr).ToNot(HaveOccurred())
+					Expect(dc.ResourceVersion).To(Equal(initialDCResourceVersion))
+				})
+			})
+
+			Context("with multiple DeviceClasses across Exactly and FirstAvailable", func() {
+				const dc2 = "fpga-class"
+
+				BeforeEach(func() {
+					createLocalDeviceClass(deviceClassName)
+					createLocalDeviceClass(dc2)
+					l := mkBasicLocalClaim()
+					l.Spec.Devices.Requests = append(l.Spec.Devices.Requests, resourcev1.DeviceRequest{
+						Name: "req-2",
+						FirstAvailable: []resourcev1.DeviceSubRequest{
+							{Name: "s1", DeviceClassName: dc2},
+							{Name: "s2", DeviceClassName: deviceClassName}, // duplicate
+						},
+					})
+					createLocalClaim(l)
+				})
+
+				It("should reflect each unique DeviceClass exactly once on the remote", func() {
+					Expect(err).ToNot(HaveOccurred())
+					_, gerr := remoteClient.ResourceV1().DeviceClasses().Get(ctx, deviceClassName, metav1.GetOptions{})
+					Expect(gerr).ToNot(HaveOccurred())
+					_, gerr = remoteClient.ResourceV1().DeviceClasses().Get(ctx, dc2, metav1.GetOptions{})
+					Expect(gerr).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when the local exists and the remote already exists and is reflected", func() {
+			Context("with the same labels and annotations as desired", func() {
+				var rvBefore string
+
+				BeforeEach(func() {
+					createLocalDeviceClass(deviceClassName)
+					createRemoteDeviceClass(deviceClassName)
+					local := createLocalClaim(mkBasicLocalClaim())
+
+					desired := forge.RemoteResourceClaim(local, RemoteNamespace,
+						testutil.FakeForgingOpts().LabelsNotReflected,
+						testutil.FakeForgingOpts().AnnotationsNotReflected)
+					created := createRemoteClaim(desired)
+					rvBefore = created.ResourceVersion
+				})
+
+				It("should be a no-op (resourceVersion unchanged)", func() {
+					Expect(err).ToNot(HaveOccurred())
+					rc, gerr := remoteClient.ResourceV1().ResourceClaims(RemoteNamespace).Get(ctx, claimName, metav1.GetOptions{})
+					Expect(gerr).ToNot(HaveOccurred())
+					Expect(rc.ResourceVersion).To(Equal(rvBefore))
+				})
+			})
+
+			Context("with stale labels", func() {
+				BeforeEach(func() {
+					createLocalDeviceClass(deviceClassName)
+					createRemoteDeviceClass(deviceClassName)
+					createLocalClaim(mkBasicLocalClaim())
+
+					stale := &resourcev1.ResourceClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: claimName,
+							Labels: map[string]string{
+								forge.LiqoOriginClusterIDKey:      LocalClusterID,
+								forge.LiqoDestinationClusterIDKey: RemoteClusterID,
+								"old":                             "label",
+							},
+						},
+						Spec: resourcev1.ResourceClaimSpec{
+							Devices: resourcev1.DeviceClaim{
+								Requests: []resourcev1.DeviceRequest{{
+									Name:    fakeClaimName,
+									Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: deviceClassName, Count: 1},
+								}},
+							},
+						},
+					}
+					createRemoteClaim(stale)
+				})
+
+				It("should update labels on the remote claim", func() {
+					Expect(err).ToNot(HaveOccurred())
+					rc, gerr := remoteClient.ResourceV1().ResourceClaims(RemoteNamespace).Get(ctx, claimName, metav1.GetOptions{})
+					Expect(gerr).ToNot(HaveOccurred())
+					Expect(rc.Labels).To(HaveKeyWithValue(fooVal, barVal))
+					Expect(rc.Labels).ToNot(HaveKey("old"))
+				})
+			})
+		})
+
+		Context("when a non-reflected remote claim exists", func() {
+			var rvBefore string
+
+			BeforeEach(func() {
+				createLocalDeviceClass(deviceClassName)
+				createLocalClaim(mkBasicLocalClaim())
+				existing := &resourcev1.ResourceClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: claimName},
+					Spec: resourcev1.ResourceClaimSpec{
+						Devices: resourcev1.DeviceClaim{
+							Requests: []resourcev1.DeviceRequest{{
+								Name:    fakeClaimName,
+								Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: deviceClassName, Count: 1},
+							}},
+						},
+					},
+				}
+				created := createRemoteClaim(existing)
+				rvBefore = created.ResourceVersion
+			})
+
+			It("should skip without modifying the remote claim", func() {
+				Expect(err).ToNot(HaveOccurred())
+				rc, gerr := remoteClient.ResourceV1().ResourceClaims(RemoteNamespace).Get(ctx, claimName, metav1.GetOptions{})
+				Expect(gerr).ToNot(HaveOccurred())
+				Expect(rc.ResourceVersion).To(Equal(rvBefore))
+			})
+		})
+
+		Context("when the local is missing and the remote exists", func() {
+			Context("and the remote is reflected by Liqo", func() {
+				BeforeEach(func() {
+					createRemoteClaim(&resourcev1.ResourceClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   claimName,
+							Labels: forge.ReflectionLabels(),
+						},
+						Spec: resourcev1.ResourceClaimSpec{
+							Devices: resourcev1.DeviceClaim{
+								Requests: []resourcev1.DeviceRequest{{
+									Name:    fakeClaimName,
+									Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: deviceClassName, Count: 1},
+								}},
+							},
+						},
+					})
+				})
+
+				It("should delete the remote claim", func() {
+					Expect(err).ToNot(HaveOccurred())
+					_, gerr := remoteClient.ResourceV1().ResourceClaims(RemoteNamespace).Get(ctx, claimName, metav1.GetOptions{})
+					Expect(kerrors.IsNotFound(gerr)).To(BeTrue())
+				})
+			})
+
+			Context("and the remote is NOT reflected by Liqo", func() {
+				var rvBefore string
+
+				BeforeEach(func() {
+					created := createRemoteClaim(&resourcev1.ResourceClaim{
+						ObjectMeta: metav1.ObjectMeta{Name: claimName},
+						Spec: resourcev1.ResourceClaimSpec{
+							Devices: resourcev1.DeviceClaim{
+								Requests: []resourcev1.DeviceRequest{{
+									Name:    fakeClaimName,
+									Exactly: &resourcev1.ExactDeviceRequest{DeviceClassName: deviceClassName, Count: 1},
+								}},
+							},
+						},
+					})
+					rvBefore = created.ResourceVersion
+				})
+
+				It("should leave the remote claim untouched", func() {
+					Expect(err).ToNot(HaveOccurred())
+					rc, gerr := remoteClient.ResourceV1().ResourceClaims(RemoteNamespace).Get(ctx, claimName, metav1.GetOptions{})
+					Expect(gerr).ToNot(HaveOccurred())
+					Expect(rc.ResourceVersion).To(Equal(rvBefore))
+				})
+			})
+		})
+	})
+})

--- a/pkg/virtualKubelet/reflection/dra/resourceslice.go
+++ b/pkg/virtualKubelet/reflection/dra/resourceslice.go
@@ -1,0 +1,345 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dra
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	resourcev1listers "k8s.io/client-go/listers/resource/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/leaderelection"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/generic"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/manager"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
+)
+
+const (
+	// ResourceSliceReflectorName is the name associated with the ResourceSlice reflector.
+	ResourceSliceReflectorName = "ResourceSlice"
+)
+
+var _ manager.Reflector = (*ResourceSliceReflector)(nil)
+
+// ResourceSliceReflector is a cluster-scoped, leader-only reflector that mirrors
+// ResourceSlice objects from the remote cluster into the local cluster. The leader VK
+// across the peering handles slices for every node in the peering, not just its own.
+type ResourceSliceReflector struct {
+	name    string
+	workers uint
+
+	localClient  kubernetes.Interface
+	remoteClient kubernetes.Interface
+	resync       time.Duration
+
+	workqueue workqueue.TypedRateLimitingInterface[types.NamespacedName]
+
+	// Listers populated in Start.
+	localSlices  resourcev1listers.ResourceSliceLister
+	remoteSlices resourcev1listers.ResourceSliceLister
+	localNodes   corev1listers.NodeLister
+
+	forgingOpts *forge.ForgingOpts
+}
+
+// NewResourceSliceReflector returns a new ResourceSliceReflector. When the configured
+// number of workers is zero, a dummy reflector is returned that performs no work.
+func NewResourceSliceReflector(localClient, remoteClient kubernetes.Interface,
+	resync time.Duration, reflectorConfig *offloadingv1beta1.ReflectorConfig) manager.Reflector {
+	if reflectorConfig.NumWorkers == 0 {
+		return generic.NewDummyReflector(ResourceSliceReflectorName)
+	}
+
+	return &ResourceSliceReflector{
+		name:         ResourceSliceReflectorName,
+		workers:      reflectorConfig.NumWorkers,
+		localClient:  localClient,
+		remoteClient: remoteClient,
+		resync:       resync,
+		workqueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[types.NamespacedName](),
+			workqueue.TypedRateLimitingQueueConfig[types.NamespacedName]{Name: ResourceSliceReflectorName}),
+	}
+}
+
+// String returns the name of the reflector.
+func (rsr *ResourceSliceReflector) String() string { return rsr.name }
+
+// Start sets up the cluster-scoped local and remote informers and launches the workers.
+// StartNamespace is a no-op for this reflector.
+func (rsr *ResourceSliceReflector) Start(ctx context.Context, opts *options.ReflectorOpts) {
+	klog.Infof("Starting the %v reflector with %v workers (leader-only)", rsr.name, rsr.workers)
+	rsr.forgingOpts = opts.ForgingOpts
+	if rsr.forgingOpts == nil {
+		rsr.forgingOpts = &forge.ForgingOpts{}
+	}
+
+	localFactory := informers.NewSharedInformerFactory(rsr.localClient, rsr.resync)
+	remoteFactory := informers.NewSharedInformerFactory(rsr.remoteClient, rsr.resync)
+	// Separate factory for nodes to just listen on the virtual nodes changes.
+	nodeFactory := informers.NewSharedInformerFactoryWithOptions(rsr.localClient, rsr.resync,
+		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+			opts.LabelSelector = consts.TypeLabel + "=" + consts.TypeNode
+		}),
+	)
+
+	localSliceInformer := localFactory.Resource().V1().ResourceSlices()
+	remoteSliceInformer := remoteFactory.Resource().V1().ResourceSlices()
+	localNodeInformer := nodeFactory.Core().V1().Nodes()
+
+	_, err := localSliceInformer.Informer().AddEventHandler(rsr.handlers())
+	utilruntime.Must(err)
+	_, err = remoteSliceInformer.Informer().AddEventHandler(rsr.handlers())
+	utilruntime.Must(err)
+	// When a virtual node appears, enqueue the remote slices for that node,
+	// as they may have been skipped due to the missing local node.
+	_, err = localNodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			node, ok := obj.(*corev1.Node)
+			if !ok {
+				return
+			}
+			rsr.enqueueRemoteSlicesForNode(node.Name)
+		},
+	})
+	utilruntime.Must(err)
+
+	rsr.localSlices = localSliceInformer.Lister()
+	rsr.remoteSlices = remoteSliceInformer.Lister()
+	rsr.localNodes = localNodeInformer.Lister()
+
+	localFactory.Start(ctx.Done())
+	remoteFactory.Start(ctx.Done())
+	nodeFactory.Start(ctx.Done())
+	localFactory.WaitForCacheSync(ctx.Done())
+	remoteFactory.WaitForCacheSync(ctx.Done())
+	nodeFactory.WaitForCacheSync(ctx.Done())
+
+	for i := uint(0); i < rsr.workers; i++ {
+		go wait.Until(rsr.runWorker, time.Second, ctx.Done())
+	}
+
+	go func() {
+		<-ctx.Done()
+		rsr.workqueue.ShutDown()
+	}()
+}
+
+// StartNamespace is a no-op: the reflector is cluster-scoped.
+func (rsr *ResourceSliceReflector) StartNamespace(_ *options.NamespacedOpts) {}
+
+// StopNamespace is a no-op: the reflector is cluster-scoped.
+func (rsr *ResourceSliceReflector) StopNamespace(_, _ string) {}
+
+// Resync re-enqueues every known remote and local slice so orphaned local
+// slices (missed remote-delete events) also get reconciled.
+func (rsr *ResourceSliceReflector) Resync() error {
+	if rsr.remoteSlices != nil {
+		remote, err := rsr.remoteSlices.List(labels.Everything())
+		if err != nil {
+			klog.Errorf("Failed to list remote ResourceSlices for resync: %v", err)
+		} else {
+			for _, s := range remote {
+				rsr.workqueue.Add(types.NamespacedName{Name: s.Name})
+			}
+		}
+	}
+	if rsr.localSlices != nil {
+		local, err := rsr.localSlices.List(labels.Everything())
+		if err != nil {
+			klog.Errorf("Failed to list local ResourceSlices for resync: %v", err)
+		} else {
+			for _, s := range local {
+				rsr.workqueue.Add(types.NamespacedName{Name: s.Name})
+			}
+		}
+	}
+	return nil
+}
+
+// enqueueRemoteSlicesForNode enqueues only the remote slices whose Spec.NodeName
+// matches the given local virtual node name.
+func (rsr *ResourceSliceReflector) enqueueRemoteSlicesForNode(nodeName string) {
+	if rsr.remoteSlices == nil {
+		return
+	}
+	slices, err := rsr.remoteSlices.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Failed to list remote ResourceSlices: %v", err)
+		return
+	}
+	for _, s := range slices {
+		if s.Spec.NodeName != nil && *s.Spec.NodeName == nodeName {
+			rsr.workqueue.Add(types.NamespacedName{Name: s.Name})
+		}
+	}
+}
+
+func (rsr *ResourceSliceReflector) handlers() cache.ResourceEventHandler {
+	enqueue := func(ev watch.EventType, obj any) {
+		if ev == watch.Deleted {
+			switch t := obj.(type) {
+			case cache.DeletedFinalStateUnknown:
+				obj = t.Obj
+			case *cache.DeletedFinalStateUnknown:
+				obj = t.Obj
+			}
+		}
+
+		md, err := meta.Accessor(obj)
+		if err != nil {
+			klog.Errorf("Failed metadata accessor in %v reflector: obj=%T err=%v", rsr.name, obj, err)
+			return
+		}
+		rsr.workqueue.Add(types.NamespacedName{Name: md.GetName()})
+	}
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { enqueue(watch.Added, obj) },
+		UpdateFunc: func(_, obj any) { enqueue(watch.Modified, obj) },
+		DeleteFunc: func(obj any) { enqueue(watch.Deleted, obj) },
+	}
+}
+
+func (rsr *ResourceSliceReflector) runWorker() {
+	for rsr.processNext() {
+	}
+}
+
+func (rsr *ResourceSliceReflector) processNext() bool {
+	key, shutdown := rsr.workqueue.Get()
+	if shutdown {
+		return false
+	}
+	defer rsr.workqueue.Done(key)
+
+	if !leaderelection.IsLeader() {
+		klog.V(4).Infof("Skipping %v reflector item %v because the node is not the leader", rsr.name, key)
+		return true
+	}
+
+	err := rsr.handle(context.Background(), key.Name)
+	if err != nil {
+		rsr.workqueue.AddRateLimited(key)
+		return true
+	}
+
+	rsr.workqueue.Forget(key)
+	return true
+}
+
+// handle reconciles a single ResourceSlice by name.
+func (rsr *ResourceSliceReflector) handle(ctx context.Context, name string) error {
+	klog.V(4).Infof("Handling reflection of ResourceSlice %q", name)
+
+	local, lerr := rsr.localSlices.Get(name)
+	if lerr != nil && !kerrors.IsNotFound(lerr) {
+		klog.Errorf("Failed to get local ResourceSlice %q: %v", name, lerr)
+		return fmt.Errorf("getting local ResourceSlice %q: %w", name, lerr)
+	}
+
+	// Refuse to mutate a local slice we don't own.
+	if lerr == nil && !forge.IsReflected(local) {
+		klog.V(4).Infof("Skipping reflection of ResourceSlice %q: local exists and is not managed by us", name)
+		return nil
+	}
+
+	remote, rerr := rsr.remoteSlices.Get(name)
+	if rerr != nil && !kerrors.IsNotFound(rerr) {
+		klog.Errorf("Failed to get remote ResourceSlice %q: %v", name, rerr)
+		return fmt.Errorf("getting remote ResourceSlice %q: %w", name, rerr)
+	}
+
+	// Remote vanished -> ensure local is also gone.
+	if kerrors.IsNotFound(rerr) {
+		if local != nil {
+			klog.Infof("Deleting local ResourceSlice %q since remote no longer exists", name)
+			err := rsr.localClient.ResourceV1().ResourceSlices().Delete(ctx, name,
+				*metav1.NewPreconditionDeleteOptions(string(local.GetUID())))
+			if err != nil && !kerrors.IsNotFound(err) {
+				return fmt.Errorf("deleting ResourceSlice %q: %w", name, err)
+			}
+		}
+		return nil
+	}
+
+	// We currently only handle slices whose Spec.NodeName is set.
+	// TODO: support spec.NodeSelector, spec.AllNodes and spec.PerDeviceNodeSelection.
+	if remote.Spec.NodeName == nil || *remote.Spec.NodeName == "" {
+		klog.V(4).Infof("Skipping reflection of ResourceSlice %q: spec.NodeName is unset (NodeSelector/AllNodes not yet supported)", name)
+		return nil
+	}
+
+	// Resolve the local virtual node by name. The 1:1 mapping in this fork means
+	// remote.Spec.NodeName == local virtual node name.
+	localNode, err := rsr.localNodes.Get(*remote.Spec.NodeName)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			klog.V(4).Infof("Skipping reflection of ResourceSlice %q: no local node %q yet", name, *remote.Spec.NodeName)
+			return nil
+		}
+		return fmt.Errorf("getting local node %q: %w", *remote.Spec.NodeName, err)
+	}
+
+	desired := forge.LocalResourceSlice(remote, localNode, rsr.forgingOpts.LabelsNotReflected, rsr.forgingOpts.AnnotationsNotReflected)
+
+	if kerrors.IsNotFound(lerr) {
+		if _, err := rsr.localClient.ResourceV1().ResourceSlices().Create(ctx, desired, metav1.CreateOptions{}); err != nil {
+			klog.Errorf("Failed to create local ResourceSlice %q: %v", name, err)
+			return fmt.Errorf("creating local ResourceSlice %q: %w", name, err)
+		}
+		klog.Infof("Local ResourceSlice %q successfully created (owner node: %q)", name, localNode.Name)
+		return nil
+	}
+
+	if apiequality.Semantic.DeepEqual(local.Labels, desired.Labels) &&
+		apiequality.Semantic.DeepEqual(local.Annotations, desired.Annotations) &&
+		apiequality.Semantic.DeepEqual(local.OwnerReferences, desired.OwnerReferences) &&
+		apiequality.Semantic.DeepEqual(local.Spec, desired.Spec) {
+		klog.V(4).Infof("Local ResourceSlice %q is already up-to-date", name)
+		return nil
+	}
+
+	updated := local.DeepCopy()
+	updated.Labels = desired.Labels
+	updated.Annotations = desired.Annotations
+	updated.OwnerReferences = desired.OwnerReferences
+	updated.Spec = desired.Spec
+	if _, err := rsr.localClient.ResourceV1().ResourceSlices().Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		klog.Errorf("Failed to update local ResourceSlice %q: %v", name, err)
+		return fmt.Errorf("updating local ResourceSlice %q: %w", name, err)
+	}
+	klog.V(4).Infof("Local ResourceSlice %q successfully updated", name)
+	return nil
+}

--- a/pkg/virtualKubelet/reflection/dra/resourceslice_test.go
+++ b/pkg/virtualKubelet/reflection/dra/resourceslice_test.go
@@ -1,0 +1,387 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dra_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	resourcev1listers "k8s.io/client-go/listers/resource/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
+
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/dra"
+)
+
+// errResourceSliceLister is a stub ResourceSliceLister whose Get always returns
+// the configured error. Used to test error propagation paths that envtest can't
+// reproduce via reactors (informer-backed listers swallow API errors).
+type errResourceSliceLister struct {
+	err error
+}
+
+func (e *errResourceSliceLister) List(_ labels.Selector) ([]*resourcev1.ResourceSlice, error) {
+	return nil, e.err
+}
+func (e *errResourceSliceLister) Get(_ string) (*resourcev1.ResourceSlice, error) {
+	return nil, e.err
+}
+
+func newSliceIndexer() cache.Indexer {
+	return cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+}
+
+func newNodeLister(nodes ...*corev1.Node) corev1listers.NodeLister {
+	idx := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, n := range nodes {
+		Expect(idx.Add(n)).To(Succeed())
+	}
+	return corev1listers.NewNodeLister(idx)
+}
+
+var _ = Describe("ResourceSliceReflector", func() {
+	const sliceName = "slice-1"
+
+	var (
+		reflector         *dra.ResourceSliceReflector
+		localSlicesIndex  cache.Indexer
+		remoteSlicesIndex cache.Indexer
+		localNodes        corev1listers.NodeLister
+		opts              *forge.ForgingOpts
+	)
+
+	// localNode mirrors the suite-created virtual node so OwnerReference
+	// assertions can compare against LiqoNodeUID.
+	mkLocalNode := func() *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: LiqoNodeName, UID: LiqoNodeUID},
+		}
+	}
+
+	BeforeEach(func() {
+		opts = testutil.FakeForgingOpts()
+		localSlicesIndex = newSliceIndexer()
+		remoteSlicesIndex = newSliceIndexer()
+		localNodes = newNodeLister(mkLocalNode())
+	})
+
+	JustBeforeEach(func() {
+		reflector = dra.NewResourceSliceReflectorForTest(
+			localClient, remoteClient,
+			resourcev1listers.NewResourceSliceLister(localSlicesIndex),
+			resourcev1listers.NewResourceSliceLister(remoteSlicesIndex),
+			localNodes,
+			opts,
+		)
+	})
+
+	AfterEach(func() {
+		// Best-effort cleanup of any slice the test may have created on the envtest API.
+		_ = localClient.ResourceV1().ResourceSlices().Delete(ctx, sliceName, metav1.DeleteOptions{})
+	})
+
+	Describe("handle", func() {
+		Context("when both local and remote are missing", func() {
+			It("should be a no-op and return nil", func() {
+				Expect(dra.Handle(reflector, ctx, sliceName)).To(Succeed())
+				_, err := localClient.ResourceV1().ResourceSlices().Get(ctx, sliceName, metav1.GetOptions{})
+				Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			})
+		})
+
+		Context("when the remote vanished", func() {
+			When("the local slice exists and is reflected by Liqo", func() {
+				BeforeEach(func() {
+					created, err := localClient.ResourceV1().ResourceSlices().Create(ctx, &resourcev1.ResourceSlice{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   sliceName,
+							Labels: forge.ReflectionLabels(),
+						},
+						Spec: resourcev1.ResourceSliceSpec{
+							Driver:   fakeDriverName,
+							Pool:     resourcev1.ResourcePool{Name: fakePoolName, ResourceSliceCount: 1},
+							NodeName: ptr.To(LiqoNodeName),
+						},
+					}, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(localSlicesIndex.Add(created)).To(Succeed())
+				})
+
+				It("should delete the local slice", func() {
+					Expect(dra.Handle(reflector, ctx, sliceName)).To(Succeed())
+					_, err := localClient.ResourceV1().ResourceSlices().Get(ctx, sliceName, metav1.GetOptions{})
+					Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				})
+			})
+
+			When("the local slice exists but is not reflected by Liqo", func() {
+				BeforeEach(func() {
+					created, err := localClient.ResourceV1().ResourceSlices().Create(ctx, &resourcev1.ResourceSlice{
+						ObjectMeta: metav1.ObjectMeta{Name: sliceName},
+						Spec: resourcev1.ResourceSliceSpec{
+							Driver:   fakeDriverName,
+							Pool:     resourcev1.ResourcePool{Name: fakePoolName, ResourceSliceCount: 1},
+							NodeName: ptr.To(LiqoNodeName),
+						},
+					}, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(localSlicesIndex.Add(created)).To(Succeed())
+				})
+
+				It("should not delete the local slice", func() {
+					Expect(dra.Handle(reflector, ctx, sliceName)).To(Succeed())
+					_, err := localClient.ResourceV1().ResourceSlices().Get(ctx, sliceName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
+		Context("when the remote slice exists", func() {
+			var remote *resourcev1.ResourceSlice
+
+			BeforeEach(func() {
+				remote = &resourcev1.ResourceSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: sliceName,
+						Labels: map[string]string{
+							"foo":                             barVal,
+							testutil.FakeNotReflectedLabelKey: trueVal,
+						},
+					},
+					Spec: resourcev1.ResourceSliceSpec{
+						Driver:   fakeDriverName,
+						Pool:     resourcev1.ResourcePool{Name: fakePoolName, ResourceSliceCount: 1},
+						NodeName: ptr.To(LiqoNodeName),
+						Devices:  []resourcev1.Device{{Name: "dev-1"}},
+					},
+				}
+			})
+
+			JustBeforeEach(func() { Expect(remoteSlicesIndex.Add(remote)).To(Succeed()) })
+
+			When("the remote has no NodeName", func() {
+				BeforeEach(func() { remote.Spec.NodeName = nil })
+				It("should be a no-op", func() {
+					Expect(dra.Handle(reflector, ctx, sliceName)).To(Succeed())
+					_, err := localClient.ResourceV1().ResourceSlices().Get(ctx, sliceName, metav1.GetOptions{})
+					Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				})
+			})
+
+			When("the remote has an empty-string NodeName", func() {
+				BeforeEach(func() { remote.Spec.NodeName = ptr.To("") })
+				It("should be a no-op", func() {
+					Expect(dra.Handle(reflector, ctx, sliceName)).To(Succeed())
+					_, err := localClient.ResourceV1().ResourceSlices().Get(ctx, sliceName, metav1.GetOptions{})
+					Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				})
+			})
+
+			When("the local virtual node is not in cache", func() {
+				BeforeEach(func() {
+					localNodes = newNodeLister()
+				})
+				It("should return nil and not create the local slice", func() {
+					Expect(dra.Handle(reflector, ctx, sliceName)).To(Succeed())
+					_, err := localClient.ResourceV1().ResourceSlices().Get(ctx, sliceName, metav1.GetOptions{})
+					Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				})
+			})
+
+			When("the local slice does not yet exist", func() {
+				It("should create the local slice with reflection labels and OwnerReference to the local node", func() {
+					Expect(dra.Handle(reflector, ctx, sliceName)).To(Succeed())
+
+					got, err := localClient.ResourceV1().ResourceSlices().Get(ctx, sliceName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(got.Labels).To(HaveKeyWithValue(fooVal, barVal))
+					Expect(got.Labels).ToNot(HaveKey(testutil.FakeNotReflectedLabelKey))
+					Expect(got.Labels).To(HaveKeyWithValue(forge.LiqoOriginClusterIDKey, LocalClusterID))
+					Expect(got.OwnerReferences).To(HaveLen(1))
+					Expect(got.OwnerReferences[0].Name).To(Equal(LiqoNodeName))
+					Expect(got.OwnerReferences[0].UID).To(Equal(LiqoNodeUID))
+					Expect(got.Spec.Driver).To(Equal(fakeDriverName))
+				})
+			})
+
+			When("the local slice exists, is reflected, and is already up-to-date", func() {
+				var rvBefore string
+
+				BeforeEach(func() {
+					desired := forge.LocalResourceSlice(remote, mkLocalNode(),
+						opts.LabelsNotReflected, opts.AnnotationsNotReflected)
+					created, err := localClient.ResourceV1().ResourceSlices().Create(ctx, desired, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					rvBefore = created.ResourceVersion
+					Expect(localSlicesIndex.Add(created)).To(Succeed())
+				})
+
+				It("should not issue an Update (resourceVersion unchanged)", func() {
+					Expect(dra.Handle(reflector, ctx, sliceName)).To(Succeed())
+					got, err := localClient.ResourceV1().ResourceSlices().Get(ctx, sliceName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(got.ResourceVersion).To(Equal(rvBefore))
+				})
+			})
+
+			When("the local slice exists, is reflected, but has stale labels", func() {
+				BeforeEach(func() {
+					stale := forge.LocalResourceSlice(remote, mkLocalNode(),
+						opts.LabelsNotReflected, opts.AnnotationsNotReflected)
+					stale.Labels["stale"] = "yes"
+					created, err := localClient.ResourceV1().ResourceSlices().Create(ctx, stale, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(localSlicesIndex.Add(created)).To(Succeed())
+				})
+
+				It("should issue an Update that reconciles labels to match the desired state", func() {
+					Expect(dra.Handle(reflector, ctx, sliceName)).To(Succeed())
+					got, err := localClient.ResourceV1().ResourceSlices().Get(ctx, sliceName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(got.Labels).ToNot(HaveKey("stale"))
+					Expect(got.Labels).To(HaveKeyWithValue(fooVal, barVal))
+					Expect(got.Labels).To(HaveKeyWithValue(forge.LiqoOriginClusterIDKey, LocalClusterID))
+				})
+			})
+
+			When("the local slice exists but is not reflected by Liqo", func() {
+				var rvBefore string
+
+				BeforeEach(func() {
+					created, err := localClient.ResourceV1().ResourceSlices().Create(ctx, &resourcev1.ResourceSlice{
+						ObjectMeta: metav1.ObjectMeta{Name: sliceName},
+						Spec: resourcev1.ResourceSliceSpec{
+							Driver:   "other",
+							Pool:     resourcev1.ResourcePool{Name: fakePoolName, ResourceSliceCount: 1},
+							NodeName: ptr.To(LiqoNodeName),
+						},
+					}, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					rvBefore = created.ResourceVersion
+					Expect(localSlicesIndex.Add(created)).To(Succeed())
+				})
+
+				It("should skip without modifying the local slice", func() {
+					Expect(dra.Handle(reflector, ctx, sliceName)).To(Succeed())
+					got, err := localClient.ResourceV1().ResourceSlices().Get(ctx, sliceName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(got.ResourceVersion).To(Equal(rvBefore))
+				})
+			})
+		})
+
+		Context("when the local lister returns a non-NotFound error", func() {
+			JustBeforeEach(func() {
+				reflector = dra.NewResourceSliceReflectorForTest(
+					localClient, remoteClient,
+					&errResourceSliceLister{err: errors.New("local boom")},
+					resourcev1listers.NewResourceSliceLister(remoteSlicesIndex),
+					localNodes,
+					opts,
+				)
+			})
+
+			It("should propagate the error", func() {
+				err := dra.Handle(reflector, ctx, sliceName)
+				Expect(err).To(MatchError(ContainSubstring("local boom")))
+			})
+		})
+
+		Context("when the remote lister returns a non-NotFound error", func() {
+			JustBeforeEach(func() {
+				reflector = dra.NewResourceSliceReflectorForTest(
+					localClient, remoteClient,
+					resourcev1listers.NewResourceSliceLister(localSlicesIndex),
+					&errResourceSliceLister{err: errors.New("remote boom")},
+					localNodes,
+					opts,
+				)
+			})
+
+			It("should propagate the error", func() {
+				err := dra.Handle(reflector, ctx, sliceName)
+				Expect(err).To(MatchError(ContainSubstring("remote boom")))
+			})
+		})
+	})
+
+	Describe("enqueueRemoteSlicesForNode", func() {
+		mkSlice := func(name, nodeName string) *resourcev1.ResourceSlice {
+			s := &resourcev1.ResourceSlice{ObjectMeta: metav1.ObjectMeta{Name: name}}
+			if nodeName != "" {
+				s.Spec.NodeName = ptr.To(nodeName)
+			}
+			return s
+		}
+
+		It("should only enqueue slices whose NodeName matches", func() {
+			Expect(remoteSlicesIndex.Add(mkSlice("a", LiqoNodeName))).To(Succeed())
+			Expect(remoteSlicesIndex.Add(mkSlice("b", "other-node"))).To(Succeed())
+			Expect(remoteSlicesIndex.Add(mkSlice("c", LiqoNodeName))).To(Succeed())
+
+			before := reflector.WorkqueueLen()
+			dra.EnqueueRemoteSlicesForNode(reflector, LiqoNodeName)
+			added := reflector.WorkqueueLen() - before
+			Expect(added).To(Equal(2))
+		})
+
+		It("should skip slices with nil NodeName", func() {
+			Expect(remoteSlicesIndex.Add(mkSlice("a", ""))).To(Succeed())
+
+			before := reflector.WorkqueueLen()
+			dra.EnqueueRemoteSlicesForNode(reflector, LiqoNodeName)
+			Expect(reflector.WorkqueueLen() - before).To(Equal(0))
+		})
+
+		It("should not panic on an empty cache", func() {
+			Expect(func() { dra.EnqueueRemoteSlicesForNode(reflector, LiqoNodeName) }).ToNot(Panic())
+		})
+	})
+
+	Describe("Resync", func() {
+		It("should add nothing to the workqueue when there are no slices", func() {
+			before := reflector.WorkqueueLen()
+			Expect(reflector.Resync()).To(Succeed())
+			Expect(reflector.WorkqueueLen() - before).To(Equal(0))
+		})
+
+		It("should enqueue every remote slice when only remotes exist", func() {
+			Expect(remoteSlicesIndex.Add(&resourcev1.ResourceSlice{ObjectMeta: metav1.ObjectMeta{Name: "a"}})).To(Succeed())
+			Expect(remoteSlicesIndex.Add(&resourcev1.ResourceSlice{ObjectMeta: metav1.ObjectMeta{Name: "b"}})).To(Succeed())
+
+			before := reflector.WorkqueueLen()
+			Expect(reflector.Resync()).To(Succeed())
+			Expect(reflector.WorkqueueLen() - before).To(Equal(2))
+		})
+
+		It("should enqueue every local slice when only locals exist", func() {
+			Expect(localSlicesIndex.Add(&resourcev1.ResourceSlice{ObjectMeta: metav1.ObjectMeta{Name: "a"}})).To(Succeed())
+			Expect(localSlicesIndex.Add(&resourcev1.ResourceSlice{ObjectMeta: metav1.ObjectMeta{Name: "b"}})).To(Succeed())
+
+			before := reflector.WorkqueueLen()
+			Expect(reflector.Resync()).To(Succeed())
+			Expect(reflector.WorkqueueLen() - before).To(Equal(2))
+		})
+	})
+})

--- a/pkg/virtualKubelet/reflection/generic/reflector.go
+++ b/pkg/virtualKubelet/reflection/generic/reflector.go
@@ -398,6 +398,12 @@ func WithoutFallback() FallbackReflectorFactoryFunc {
 	return func(ro *options.ReflectorOpts) manager.FallbackReflector { return nil }
 }
 
+// NewDummyReflector returns a dummy reflector that can be used when no workers are specified, to avoid starting the working queue and
+// registering the informers.
+func NewDummyReflector(name string) manager.Reflector {
+	return &dummyreflector{name: name}
+}
+
 type dummyreflector struct{ name string }
 
 // String returns the name of the dummy reflector.

--- a/pkg/virtualKubelet/reflection/manager/manager.go
+++ b/pkg/virtualKubelet/reflection/manager/manager.go
@@ -116,7 +116,9 @@ func (m *manager) Start(ctx context.Context) {
 	ready := false
 	for _, reflector := range m.reflectors {
 		opts := options.New(m.local, m.localPodInformerFactory.Core().V1().Pods()).
-			WithReadinessFunc(func() bool { return ready }).WithEventBroadcaster(m.eventBroadcaster)
+			WithReadinessFunc(func() bool { return ready }).
+			WithEventBroadcaster(m.eventBroadcaster).
+			WithForgingOpts(&m.forgingOpts)
 		reflector.Start(ctx, opts)
 	}
 

--- a/pkg/virtualKubelet/reflection/options/options.go
+++ b/pkg/virtualKubelet/reflection/options/options.go
@@ -41,6 +41,7 @@ type ReflectorOpts struct {
 	LocalClient      kubernetes.Interface
 	LocalPodInformer corev1informers.PodInformer
 	EventBroadcaster record.EventBroadcaster
+	ForgingOpts      *forge.ForgingOpts
 
 	HandlerFactory func(Keyer, ...EventFilter) cache.ResourceEventHandler
 
@@ -64,9 +65,15 @@ func (ro *ReflectorOpts) WithReadinessFunc(ready func() bool) *ReflectorOpts {
 	return ro
 }
 
-// WithEventBroadcaster configures the event broadcaster of the NamespacedOpts.
+// WithEventBroadcaster configures the event broadcaster of the ReflectorOpts.
 func (ro *ReflectorOpts) WithEventBroadcaster(broadcaster record.EventBroadcaster) *ReflectorOpts {
 	ro.EventBroadcaster = broadcaster
+	return ro
+}
+
+// WithForgingOpts configures the reflection options of the ReflectorOpts.
+func (ro *ReflectorOpts) WithForgingOpts(opts *forge.ForgingOpts) *ReflectorOpts {
+	ro.ForgingOpts = opts
 	return ro
 }
 

--- a/pkg/virtualKubelet/reflection/resources/resources.go
+++ b/pkg/virtualKubelet/reflection/resources/resources.go
@@ -28,10 +28,15 @@ const (
 	ServiceAccount        ResourceReflected = "serviceaccount"
 	PersistentVolumeClaim ResourceReflected = "persistentvolumeclaim"
 	Event                 ResourceReflected = "event"
+	ResourceSlice         ResourceReflected = "resourceslice"
+	ResourceClaim         ResourceReflected = "resourceclaim"
 )
 
 // Reflectors is the list of all resources that can be reflected.
-var Reflectors = []ResourceReflected{Pod, Service, EndpointSlice, Ingress, ConfigMap, Secret, ServiceAccount, PersistentVolumeClaim, Event}
+var Reflectors = []ResourceReflected{
+	Pod, Service, EndpointSlice, Ingress, ConfigMap, Secret, ServiceAccount, PersistentVolumeClaim, Event,
+	ResourceSlice, ResourceClaim,
+}
 
 // ReflectorsCustomizableType is the list of resources for which the reflection type can be customized.
 var ReflectorsCustomizableType = []ResourceReflected{Service, Ingress, ConfigMap, Secret, Event}

--- a/pkg/virtualKubelet/reflection/workload/podns.go
+++ b/pkg/virtualKubelet/reflection/workload/podns.go
@@ -337,12 +337,21 @@ func (npr *NamespacedPodReflector) ForgeShadowPod(ctx context.Context, local *co
 		return ip
 	}
 
+	// If the pod has ResourceClaims from templates, wait until the local kubelet has
+	// resolved all of them into concrete ResourceClaim names (written to Status.ResourceClaimStatuses).
+	// Until then, requeue rather than reflecting an incomplete spec to the remote.
+	if err := forge.CheckDRAClaimStatusesReady(local); err != nil {
+		return nil, fmt.Errorf("checking DRA claim statuses: %w", err)
+	}
+
 	var mutators []forge.RemotePodSpecMutator
 
 	mutators = append(mutators,
 		forge.APIServerSupportMutator(npr.config.APIServerSupport, local.Annotations, pod.ServiceAccountName(local),
 			saSecretRetriever, ipGetter, npr.config.HomeAPIServerHost, npr.config.HomeAPIServerPort),
-		forge.ServiceAccountMutator(npr.config.APIServerSupport, local.Annotations))
+		forge.ServiceAccountMutator(npr.config.APIServerSupport, local.Annotations),
+		forge.DRAClaimRewriteMutator(local.Status.ResourceClaimStatuses),
+	)
 
 	if forgingOpts != nil {
 		mutators = append(mutators,
@@ -431,7 +440,10 @@ func (npr *NamespacedPodReflector) HandleStatus(ctx context.Context, local, remo
 		info.RemoteUID = remote.GetUID()
 	}
 
-	mutators := []forge.RemotePodStatusMutator{}
+	mutators := []forge.RemotePodStatusMutator{
+		// ResourceClaimStatuses are managed locally never overwrite them with the remote pod's view.
+		forge.PreserveResourceClaimStatusesMutator(local.Status.ResourceClaimStatuses),
+	}
 	if npr.config.DisableIPReflection {
 		// If the IP reflection is disabled, we need to not reflect the IP address of the remote pod.
 		mutators = append(mutators, forge.OpaqueIPTranslationMutator())

--- a/pkg/virtualKubelet/roles/local/role.go
+++ b/pkg/virtualKubelet/roles/local/role.go
@@ -42,3 +42,7 @@ package local
 // Additional permissions necessary for the networking module
 // +kubebuilder:rbac:groups=ipam.liqo.io,resources=ips,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.liqo.io,resources=configurations,verbs=get;list;watch
+
+// Permissions for DRA reflection of ResourceSlices, ResourceClaims and DeviceClasses.
+// +kubebuilder:rbac:groups=resource.k8s.io,resources=resourceslices,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaims;deviceclasses,verbs=get;list;watch

--- a/pkg/virtualKubelet/roles/remote/role.go
+++ b/pkg/virtualKubelet/roles/remote/role.go
@@ -28,3 +28,6 @@ package remote
 
 // +kubebuilder:rbac:groups=offloading.liqo.io,resources=shadowpods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=offloading.liqo.io,resources=shadowendpointslices,verbs=get;list;watch;create;update;patch;delete
+
+// Permissions for DRA reflection of ResourceSlices, ResourceClaims and DeviceClasses.
+// +kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaims,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
# Description

Introduce VK Reflection for Key Resources

- ResourceSlice: Reflected from the remote cluster to the local cluster, but only when a corresponding virtual node exists. Currently, only ResourceSlices associated with a single node are reflected.
- ResourceClaim: Reflected from the local cluster to the remote cluster. The ResourceClaim status is not synchronized, so each cluster performs independent scheduling based on the claim’s expression.
- DeviceClass: Reflected when a ResourceClaim references a DeviceClass that does not exist in the remote cluster.

Additionally, the pod reflector now patches all ResourceClaimTemplates in local pods with the resolved ResourceClaim. This prevents the creation of additional ResourceClaims from templates in the remote cluster and ensures reuse of the ResourceClaim created locally and reflected by the VK.

For backwards compatibility with previous Kubernetes versions, the reflectors are not registered in the virtual kubelet if DRA resources are not present in the cluster

---
### Kimchi Summary
### What changed
Adds reflection support for Kubernetes Dynamic Resource Allocation (DRA) resources (`ResourceSlice`, `ResourceClaim`, and `DeviceClass`) to the virtual kubelet. When both peered clusters expose the `resource.k8s.io/v1` API, the virtual kubelet automatically mirrors resource slices from the remote cluster into the local cluster and propagates resource claims (plus their referenced device classes) from local to remote.

### Why
This enables Liqo to offload pods that request dedicated hardware via DRA. Without reflecting these objects, the remote cluster cannot schedule or track DRA-backed workloads originating from the local cluster.

### Key changes
- `cmd/virtual-kubelet/root/opts.go`, `root.go`: Registered `ResourceSlice` and `ResourceClaim` with default workers and reflection types, and marked them as non-customizable.
- `deployments/liqo/values.yaml`, `templates/liqo-vk-options-template.yaml`, `README.md`: Added Helm values for DRA reflector workers (`resourceslice` and `resourceclaim`).
- `deployments/liqo/files/liqo-virtual-kubelet-*-ClusterRole.yaml`: Granted RBAC permissions for `resource.k8s.io` resources (`deviceclasses`, `resourceclaims`, `resourceslices`).
- `pkg/virtualKubelet/reflection/dra/`: New package implementing:
  - `IsDRASupportedOnBothClusters`: Probes both clusters for `resource.k8s.io/v1` availability before registering reflectors.
  - `ResourceSliceReflector`: Leader-only, cluster-scoped reflector that mirrors remote `ResourceSlices` locally and anchors them to the virtual node via `OwnerReference`.
  - `ResourceClaimReflector`: Namespaced reflector that mirrors local `ResourceClaims` to the remote cluster; ensures referenced `DeviceClasses` are created remotely before the claim.
  - `ensureRemoteDeviceClass`: Copies missing `DeviceClass` objects from local to remote.
- `pkg/virtualKubelet/forge/dra.go`: Added forging helpers `LocalResourceSlice`, `RemoteResourceClaim`, `RemoteDeviceClass`, and `ReferencedDeviceClasses`.
- `pkg/virtualKubelet/forge/pods.go`: Added `CheckDRAClaimStatusesReady`, `DRAClaimRewriteMutator`, and `PreserveResourceClaimStatusesMutator` to correctly propagate and protect `Pod` `ResourceClaims` and `ResourceClaimStatuses` during offloading.
- `pkg/utils/cluster_info.go`: Fixed a missing error check before mutating the REST config timeout.

### Impact
- DRA reflection is automatically disabled if either cluster does not expose the `resource.k8s.io/v1` API.
- `ResourceSlice` reflection runs only on the leader virtual-kubelet instance.
- `ResourceClaim` specs are immutable after creation; subsequent reconciliations only update labels and annotations.
- The virtual kubelet now requires additional ClusterRole permissions for `resource.k8s.io` resources.