### PR TITLE
fix(vk): forge Node with VirtualNode, ForeignCluster input

### DIFF
--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -262,6 +262,34 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 	if c.CreateNode {
 		var nodeReady chan struct{}
 		var nodeRunner *node.NodeController
+
+		remoteCl, err := client.New(remoteConfig, client.Options{Scheme: scheme})
+		if err != nil {
+			return fmt.Errorf("creating remote client: %w", err)
+		}
+		var remoteNode corev1.Node
+		var remoteNodePtr *corev1.Node
+		err = remoteCl.Get(ctx, client.ObjectKey{Name: c.NodeName}, &remoteNode) // local node name matches with remote node name
+		if err != nil && !k8serrors.IsForbidden(err) {
+			return fmt.Errorf("getting remote node: %w", err)
+		}
+
+		var remoteNodeInfo *corev1.NodeSystemInfo
+		var providerID string
+		// If the error is forbidden, it means that the virtual kubelet does not have permissions to get the remote node.
+		// This can happen if remote cluster is running a older liqo version. In such cases, we keep legacy behavior (defaulting
+		// node info fields) and we do not watch the remote node for updates.
+		if k8serrors.IsForbidden(err) {
+			klog.Warning("Unable to get remote node due to missing permissions; defaulting node info fields and skipping remote node watching")
+		}
+		if err == nil {
+			remoteNodeInfo = &remoteNode.Status.NodeInfo
+			remoteNodePtr = &remoteNode
+			if remoteNode.Spec.ProviderID != "" && strings.HasPrefix(remoteNode.Spec.ProviderID, "castai-omni://") {
+				providerID = remoteNode.Spec.ProviderID
+			}
+		}
+
 		// Initialize the node provider
 		nodecfg := nodeprovider.InitConfig{
 			HomeConfig:      localConfig,
@@ -283,30 +311,7 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 
 			VirtualNode:    &vn,
 			ForeignCluster: foreignCluster,
-		}
-
-		remoteCl, err := client.New(remoteConfig, client.Options{Scheme: scheme})
-		if err != nil {
-			return fmt.Errorf("creating remote client: %w", err)
-		}
-		var remoteNode corev1.Node
-		err = remoteCl.Get(ctx, client.ObjectKey{Name: c.NodeName}, &remoteNode) // local node name matches with remote node name
-		if err != nil && !k8serrors.IsForbidden(err) {
-			return fmt.Errorf("getting remote node: %w", err)
-		}
-		var remoteNodeInfo *corev1.NodeSystemInfo
-		var providerID string
-		// If the error is forbidden, it means that the virtual kubelet does not have permissions to get the remote node.
-		// This can happen if remote cluster is running a older liqo version. In such cases, we keep legacy behavior (defaulting
-		// node info fields) and we do not watch the remote node for updates.
-		if k8serrors.IsForbidden(err) {
-			klog.Warning("Unable to get remote node due to missing permissions; defaulting node info fields and skipping remote node watching")
-		}
-		if err == nil {
-			remoteNodeInfo = &remoteNode.Status.NodeInfo
-			if remoteNode.Spec.ProviderID != "" && strings.HasPrefix(remoteNode.Spec.ProviderID, "castai-omni://") {
-				providerID = remoteNode.Spec.ProviderID
-			}
+			RemoteNode:     remoteNodePtr,
 		}
 
 		nodeProvider := nodeprovider.NewLiqoNodeProvider(&nodecfg, remoteNodeInfo, providerID)

--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -274,8 +273,6 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 			return fmt.Errorf("getting remote node: %w", err)
 		}
 
-		var remoteNodeInfo *corev1.NodeSystemInfo
-		var providerID string
 		// If the error is forbidden, it means that the virtual kubelet does not have permissions to get the remote node.
 		// This can happen if remote cluster is running a older liqo version. In such cases, we keep legacy behavior (defaulting
 		// node info fields) and we do not watch the remote node for updates.
@@ -283,11 +280,7 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 			klog.Warning("Unable to get remote node due to missing permissions; defaulting node info fields and skipping remote node watching")
 		}
 		if err == nil {
-			remoteNodeInfo = &remoteNode.Status.NodeInfo
 			remoteNodePtr = &remoteNode
-			if remoteNode.Spec.ProviderID != "" && strings.HasPrefix(remoteNode.Spec.ProviderID, "castai-omni://") {
-				providerID = remoteNode.Spec.ProviderID
-			}
 		}
 
 		// Initialize the node provider
@@ -314,7 +307,7 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 			RemoteNode:     remoteNodePtr,
 		}
 
-		nodeProvider := nodeprovider.NewLiqoNodeProvider(&nodecfg, remoteNodeInfo, providerID)
+		nodeProvider := nodeprovider.NewLiqoNodeProvider(&nodecfg)
 		nodeReady = nodeProvider.StartProvider(ctx)
 
 		nodeRunner, err = node.NewNodeController(

--- a/pkg/virtualKubelet/liqoNodeProvider/nodeProvider.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/nodeProvider.go
@@ -119,7 +119,7 @@ func (p *LiqoNodeProvider) GetNode() *corev1.Node {
 // hydrate pre-populates the in-memory node state from the available source objects.
 // It does not publish node updates and does not patch the local Kubernetes Node object.
 func (p *LiqoNodeProvider) hydrate(
-	foreignCluster *liqov1beta1.ForeignCluster, virtualNode *offloadingv1beta1.VirtualNode,
+	foreignCluster *liqov1beta1.ForeignCluster, remoteNode *corev1.Node, virtualNode *offloadingv1beta1.VirtualNode,
 ) {
 	p.updateMutex.Lock()
 	defer p.updateMutex.Unlock()
@@ -130,6 +130,9 @@ func (p *LiqoNodeProvider) hydrate(
 	}
 	if foreignCluster != nil {
 		p.applyForeignCluster(foreignCluster)
+	}
+	if remoteNode != nil {
+		p.remoteNodeStatus = remoteNode.Status
 	}
 
 	p.recomputeNodeState()

--- a/pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go
@@ -95,7 +95,7 @@ var _ = Describe("NodeProvider", func() {
 			PodProviderStopper: podStopper,
 
 			CheckNetworkStatus: true,
-		}, nil, "")
+		})
 
 		_, err = client.CoreV1().Nodes().Create(ctx, nodeProvider.GetNode(), metav1.CreateOptions{})
 		Expect(err).To(BeNil())
@@ -421,7 +421,7 @@ var _ = Describe("NodeProvider", func() {
 			VirtualNode:        virtualNode,
 			ForeignCluster:     foreignCluster,
 			RemoteNode:         remoteNode,
-		}, &v1.NodeSystemInfo{KubeletVersion: "v1.35.0"}, "provider-id")
+		})
 
 		hydratedNode := hydratedProvider.GetNode()
 
@@ -479,7 +479,7 @@ var _ = Describe("NodeProvider", func() {
 			VirtualNode:        virtualNode,
 			ForeignCluster:     nil,
 			RemoteNode:         nil,
-		}, &v1.NodeSystemInfo{KubeletVersion: "v1.35.1"}, "provider-id")
+		})
 
 		hydratedNode := hydratedProvider.GetNode()
 

--- a/pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go
@@ -34,6 +34,7 @@ import (
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/utils/testutil"
 )
 
@@ -343,6 +344,149 @@ var _ = Describe("NodeProvider", func() {
 			},
 		}),
 	)
+
+	It("hydrates the node from virtual node, foreign cluster and remote node", func() {
+		virtualNode := &offloadingv1beta1.VirtualNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeName,
+				Namespace: kubeletNamespace,
+			},
+			Spec: offloadingv1beta1.VirtualNodeSpec{
+				Labels: map[string]string{
+					"virtual-label": "virtual-value",
+				},
+				Annotations: map[string]string{
+					"virtual-annotation": "annotation-value",
+				},
+				Taints: []v1.Taint{{
+					Key:    taintKey,
+					Value:  taintValue,
+					Effect: v1.TaintEffectNoSchedule,
+				}},
+				StorageClasses: []liqov1beta1.StorageType{{StorageClassName: "fast"}},
+				ResourceQuota: v1.ResourceQuotaSpec{
+					Hard: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("3Gi"),
+					},
+				},
+				Images: []v1.ContainerImage{{
+					Names:     []string{"nginx:latest"},
+					SizeBytes: 1234,
+				}},
+			},
+		}
+
+		foreignCluster := testutil.FakeForeignCluster(foreignClusterID, &liqov1beta1.Modules{
+			Offloading: liqov1beta1.Module{
+				Enabled: true,
+			},
+			Networking: liqov1beta1.Module{
+				Enabled: true,
+				Conditions: []liqov1beta1.Condition{{
+					Type:   liqov1beta1.NetworkConnectionStatusCondition,
+					Status: liqov1beta1.ConditionStatusEstablished,
+				}},
+			},
+		})
+		foreignCluster.Status.ObservedGeneration = 1
+
+		remoteNode := &v1.Node{
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{Type: v1.NodeReady, Status: v1.ConditionTrue},
+					{Type: v1.NodeMemoryPressure, Status: v1.ConditionFalse},
+					{Type: v1.NodeDiskPressure, Status: v1.ConditionTrue},
+					{Type: v1.NodePIDPressure, Status: v1.ConditionFalse},
+				},
+				NodeInfo: v1.NodeSystemInfo{
+					Architecture:            "arm64",
+					OperatingSystem:         "linux",
+					KernelVersion:           "6.8.0",
+					KubeletVersion:          "v1.31.0",
+					ContainerRuntimeVersion: "containerd://2.0.0",
+					OSImage:                 "Talos Linux",
+				},
+			},
+		}
+
+		hydratedProvider := NewLiqoNodeProvider(&InitConfig{
+			NodeName:           nodeName,
+			Namespace:          kubeletNamespace,
+			InternalIP:         "10.2.0.1",
+			HomeConfig:         cluster.GetCfg(),
+			RemoteConfig:       cluster.GetCfg(),
+			RemoteClusterID:    foreignClusterID,
+			CheckNetworkStatus: true,
+			VirtualNode:        virtualNode,
+			ForeignCluster:     foreignCluster,
+			RemoteNode:         remoteNode,
+		}, &v1.NodeSystemInfo{KubeletVersion: "v1.35.0"}, "provider-id")
+
+		hydratedNode := hydratedProvider.GetNode()
+
+		Expect(hydratedNode.Labels).To(HaveKeyWithValue("virtual-label", "virtual-value"))
+		Expect(hydratedNode.Labels).To(HaveKeyWithValue(consts.StorageAvailableLabel, trueValue))
+		Expect(hydratedNode.Annotations).To(HaveKeyWithValue("virtual-annotation", "annotation-value"))
+		Expect(hydratedNode.Spec.Taints).To(ContainElement(v1.Taint{
+			Key:    taintKey,
+			Value:  taintValue,
+			Effect: v1.TaintEffectNoSchedule,
+		}))
+		Expect(hydratedNode.Spec.Taints).To(ContainElement(v1.Taint{
+			Key:    consts.VirtualNodeTolerationKey,
+			Value:  trueValue,
+			Effect: v1.TaintEffectNoExecute,
+		}))
+		Expect(hydratedNode.Status.Capacity.Cpu().Cmp(resource.MustParse("2"))).To(Equal(0))
+		Expect(hydratedNode.Status.Capacity.Memory().Cmp(resource.MustParse("3Gi"))).To(Equal(0))
+		Expect(hydratedNode.Status.Allocatable.Cpu().Cmp(resource.MustParse("2"))).To(Equal(0))
+		Expect(hydratedNode.Status.Allocatable.Memory().Cmp(resource.MustParse("3Gi"))).To(Equal(0))
+		Expect(hydratedNode.Status.Images).To(Equal(virtualNode.Spec.Images))
+		Expect(hydratedNode.Status.NodeInfo).To(Equal(remoteNode.Status.NodeInfo))
+
+		Expect(lookupCondition(hydratedNode.Status.Conditions, v1.NodeReady).Status).To(Equal(v1.ConditionTrue))
+		Expect(lookupCondition(hydratedNode.Status.Conditions, v1.NodeMemoryPressure).Status).To(Equal(v1.ConditionFalse))
+		Expect(lookupCondition(hydratedNode.Status.Conditions, v1.NodeDiskPressure).Status).To(Equal(v1.ConditionTrue))
+		Expect(lookupCondition(hydratedNode.Status.Conditions, v1.NodePIDPressure).Status).To(Equal(v1.ConditionFalse))
+		Expect(lookupCondition(hydratedNode.Status.Conditions, v1.NodeNetworkUnavailable).Status).To(Equal(v1.ConditionFalse))
+	})
+
+	It("hydrates the node when virtual node labels and annotations are nil", func() {
+		virtualNode := &offloadingv1beta1.VirtualNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeName,
+				Namespace: kubeletNamespace,
+			},
+			Spec: offloadingv1beta1.VirtualNodeSpec{
+				ResourceQuota: v1.ResourceQuotaSpec{
+					Hard: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("3Gi"),
+					},
+				},
+			},
+		}
+
+		hydratedProvider := NewLiqoNodeProvider(&InitConfig{
+			NodeName:           nodeName,
+			Namespace:          kubeletNamespace,
+			InternalIP:         "10.0.0.1",
+			HomeConfig:         cluster.GetCfg(),
+			RemoteConfig:       cluster.GetCfg(),
+			RemoteClusterID:    foreignClusterID,
+			CheckNetworkStatus: true,
+			VirtualNode:        virtualNode,
+			ForeignCluster:     nil,
+			RemoteNode:         nil,
+		}, &v1.NodeSystemInfo{KubeletVersion: "v1.35.1"}, "provider-id")
+
+		hydratedNode := hydratedProvider.GetNode()
+
+		Expect(hydratedNode.Labels).To(HaveKeyWithValue(consts.StorageAvailableLabel, "false"))
+		Expect(hydratedNode.Annotations).ToNot(BeNil())
+		Expect(hydratedNode.Annotations).ToNot(HaveKey("virtual-annotation"))
+	})
 
 	It("Labels patch", func() {
 

--- a/pkg/virtualKubelet/liqoNodeProvider/setup.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/setup.go
@@ -63,6 +63,7 @@ type InitConfig struct {
 
 	VirtualNode    *offloadingv1beta1.VirtualNode
 	ForeignCluster *liqov1beta1.ForeignCluster
+	RemoteNode     *corev1.Node
 }
 
 // NewLiqoNodeProvider creates and returns a new LiqoNodeProvider.
@@ -90,7 +91,7 @@ func NewLiqoNodeProvider(cfg *InitConfig, remoteNodeInfo *corev1.NodeSystemInfo,
 		tenantNamespace:  cfg.Namespace,
 	}
 
-	nodeProvider.hydrate(cfg.ForeignCluster, cfg.VirtualNode)
+	nodeProvider.hydrate(cfg.ForeignCluster, cfg.RemoteNode, cfg.VirtualNode)
 
 	return nodeProvider
 }

--- a/pkg/virtualKubelet/liqoNodeProvider/setup.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/setup.go
@@ -67,20 +67,20 @@ type InitConfig struct {
 }
 
 // NewLiqoNodeProvider creates and returns a new LiqoNodeProvider.
-func NewLiqoNodeProvider(cfg *InitConfig, remoteNodeInfo *corev1.NodeSystemInfo, providerID string) *LiqoNodeProvider {
+func NewLiqoNodeProvider(cfg *InitConfig) *LiqoNodeProvider {
 	nodeProvider := &LiqoNodeProvider{
 		localClient:           kubernetes.NewForConfigOrDie(cfg.HomeConfig),
 		remoteDiscoveryClient: discovery.NewDiscoveryClientForConfigOrDie(cfg.RemoteConfig),
 		dynClient:             dynamic.NewForConfigOrDie(cfg.HomeConfig),
 		remoteDynClient:       dynamic.NewForConfigOrDie(cfg.RemoteConfig),
 
-		node:              node(cfg, remoteNodeInfo, providerID),
+		node:              node(cfg),
 		terminating:       false,
 		lastAppliedLabels: map[string]string{},
 
 		networkModuleEnabled: nil, // set once ForeignCluster is first observed
 		networkReady:         false,
-		watchRemoteNode:      remoteNodeInfo != nil, // watch the remote node only if we were able to retrieve its info
+		watchRemoteNode:      cfg.RemoteNode != nil, // watch the remote node only if we were able to retrieve its info
 		resyncPeriod:         cfg.InformerResyncPeriod,
 		pingDisabled:         cfg.PingDisabled,
 		checkNetworkStatus:   cfg.CheckNetworkStatus,
@@ -91,20 +91,24 @@ func NewLiqoNodeProvider(cfg *InitConfig, remoteNodeInfo *corev1.NodeSystemInfo,
 		tenantNamespace:  cfg.Namespace,
 	}
 
+	// Set node status and metadata according to the ForeignCluster, RemoteNode and VirtualNode we retrieved at startup, if available.
 	nodeProvider.hydrate(cfg.ForeignCluster, cfg.RemoteNode, cfg.VirtualNode)
 
 	return nodeProvider
 }
 
-func node(cfg *InitConfig, remoteNodeInfo *corev1.NodeSystemInfo, providerID string) *corev1.Node {
+func node(cfg *InitConfig) *corev1.Node {
 	// Default values for the NodeInfo fields if they cannot be retrieved from the remote cluster.
 	nodeInfo := corev1.NodeSystemInfo{
 		KubeletVersion:  cfg.Version,
 		Architecture:    architecture,
 		OperatingSystem: linuxos,
 	}
-	if remoteNodeInfo != nil {
-		nodeInfo = *remoteNodeInfo
+
+	providerID := ""
+	remoteNode := cfg.RemoteNode
+	if remoteNode != nil && remoteNode.Spec.ProviderID != "" && strings.HasPrefix(remoteNode.Spec.ProviderID, "castai-omni://") {
+		providerID = remoteNode.Spec.ProviderID
 	}
 
 	lbls := map[string]string{

--- a/pkg/virtualKubelet/liqoNodeProvider/utils.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/utils.go
@@ -53,6 +53,7 @@ func desiredVirtualNodeMetadata(
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
+
 	taints = append([]v1.Taint{}, virtualNode.Spec.Taints...)
 	taints = append(taints, v1.Taint{
 		Key:    consts.VirtualNodeTolerationKey,

--- a/pkg/virtualKubelet/liqoNodeProvider/utils.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/utils.go
@@ -53,7 +53,6 @@ func desiredVirtualNodeMetadata(
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
-
 	taints = append([]v1.Taint{}, virtualNode.Spec.Taints...)
 	taints = append(taints, v1.Taint{
 		Key:    consts.VirtualNodeTolerationKey,
@@ -146,6 +145,9 @@ func (p *LiqoNodeProvider) recomputeNodeState() {
 	}
 
 	p.node.Status.Addresses = []v1.NodeAddress{{Type: v1.NodeInternalIP, Address: p.nodeIP}}
+	if p.watchRemoteNode {
+		p.node.Status.NodeInfo = p.remoteNodeStatus.NodeInfo
+	}
 }
 
 func (p *LiqoNodeProvider) patchLabels(ctx context.Context, labels map[string]string) error {


### PR DESCRIPTION
# Description

This patch fixes an issue with the virtual kubelet: when it starts the node is created only with a subset of labels and with unknown conditions. This is because the input from VirtualNode and ForeignCluster are applied only after the node is created, during the reconcile. This patch introduces an Hydrate function, which populate the node before the creation.
This pull request refactors and modularizes the logic for updating the in-memory state of the Liqo virtual node provider, improving code maintainability and clarity. The main changes involve extracting and consolidating node metadata and status update logic into dedicated methods, introducing a new `Hydrate` method to pre-populate node state, and moving condition recomputation into a single place. This results in cleaner reconciler code and more testable, reusable logic.

**Refactoring and Modularization of Node State Management:**

* Introduced the `Hydrate` method in `LiqoNodeProvider` to pre-populate the in-memory node state from available source objects (`ForeignCluster`, `VirtualNode`, and remote node), centralizing initialization logic and removing duplication. (`pkg/virtualKubelet/liqoNodeProvider/nodeProvider.go`, `cmd/virtual-kubelet/root/root.go`) [[1]](diffhunk://#diff-8c15face70ea55acde9298d337b3be30e5e3a703444da6879a4a67486f49fc8bR119-R140) [[2]](diffhunk://#diff-99d26620ca7977176913995213c9b9cb20db4dda0db288336807dbbcb0c068a2R308-R315)
* Extracted logic for applying `VirtualNode` metadata and status, and for applying `ForeignCluster` status, into new helper methods: `applyVirtualNodeMetadata`, `applyVirtualNodeStatus`, and `applyForeignCluster`. (`pkg/virtualKubelet/liqoNodeProvider/utils.go`)
* Moved the logic for recomputing node conditions and status into a new `recomputeNodeState` method, which is now called whenever relevant state changes, ensuring consistent and centralized updates. (`pkg/virtualKubelet/liqoNodeProvider/utils.go`, `pkg/virtualKubelet/liqoNodeProvider/reconciler.go`) [[1]](diffhunk://#diff-9838a1742b1f3e9348e950f13b80cd0e5723cf08f55e1d2d914850d5235770dbR20-R213) [[2]](diffhunk://#diff-96e0ab21b8be79e69f2bc566878f911dc969d5d04c3f927dce6392886e71ae45L194-L238)

**Simplification and Cleanup of Reconciler Logic:**

* Updated the reconciler methods (`updateFromVirtualNode`, `updateFromForeignCluster`, `updateNode`) to use the new helper methods, removing inline logic for updating node metadata and status, and improving readability. (`pkg/virtualKubelet/liqoNodeProvider/reconciler.go`) [[1]](diffhunk://#diff-96e0ab21b8be79e69f2bc566878f911dc969d5d04c3f927dce6392886e71ae45L120-R130) [[2]](diffhunk://#diff-96e0ab21b8be79e69f2bc566878f911dc969d5d04c3f927dce6392886e71ae45L174-R139) [[3]](diffhunk://#diff-96e0ab21b8be79e69f2bc566878f911dc969d5d04c3f927dce6392886e71ae45L194-L238)
* Removed redundant or duplicated code for patching labels, annotations, and taints from the reconciler, consolidating it into shared helper methods. (`pkg/virtualKubelet/liqoNodeProvider/reconciler.go`, `pkg/virtualKubelet/liqoNodeProvider/utils.go`) [[1]](diffhunk://#diff-96e0ab21b8be79e69f2bc566878f911dc969d5d04c3f927dce6392886e71ae45L257-L334) [[2]](diffhunk://#diff-9838a1742b1f3e9348e950f13b80cd0e5723cf08f55e1d2d914850d5235770dbR20-R213)

**Dependency and Import Adjustments:**

* Updated imports to reflect the new modular structure and remove unused dependencies. (`pkg/virtualKubelet/liqoNodeProvider/nodeProvider.go`, `pkg/virtualKubelet/liqoNodeProvider/reconciler.go`, `pkg/virtualKubelet/liqoNodeProvider/utils.go`) [[1]](diffhunk://#diff-8c15face70ea55acde9298d337b3be30e5e3a703444da6879a4a67486f49fc8bR31) [[2]](diffhunk://#diff-96e0ab21b8be79e69f2bc566878f911dc969d5d04c3f927dce6392886e71ae45L20-L35) [[3]](diffhunk://#diff-9838a1742b1f3e9348e950f13b80cd0e5723cf08f55e1d2d914850d5235770dbR20-R213)


---
### Kimchi Summary
### What changed
Refactored virtual kubelet initialization to pass the full remote `Node` object into the node provider instead of pre-extracted fields. The provider now synchronizes `NodeInfo` from the remote node during state recomputation when remote node watching is enabled.

### Why
Ensures the virtual node's system information remains consistent with the remote cluster's actual node state, rather than only reflecting it at startup.

### Key changes
- `cmd/virtual-kubelet/root/root.go`: Fetches the remote node before initializing the provider and passes it as `InitConfig.RemoteNode`. Removed unused `strings` import.
- `pkg/virtualKubelet/liqoNodeProvider/setup.go`: Added `RemoteNode` to `InitConfig`; simplified `NewLiqoNodeProvider` signature; moved `ProviderID` extraction into `node()`.
- `pkg/virtualKubelet/liqoNodeProvider/nodeProvider.go`: Updated `hydrate()` to store `remoteNode.Status` as `remoteNodeStatus`.
- `pkg/virtualKubelet/liqoNodeProvider/utils.go`: `recomputeNodeState()` now updates `p.node.Status.NodeInfo` from `p.remoteNodeStatus.NodeInfo` when `watchRemoteNode` is true.
- `pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go`: Added hydration tests covering remote node and nil input scenarios.

### Impact
- Virtual node `Status.NodeInfo` is continuously reconciled from the remote node instead of set once at startup.
- Existing fallback behavior for legacy clusters (missing remote node permissions) is preserved.