### PR TITLE
Keep host ipc, host network, host pid on remote pod

### DIFF
--- a/pkg/virtualKubelet/forge/pods.go
+++ b/pkg/virtualKubelet/forge/pods.go
@@ -241,10 +241,9 @@ func RemotePodSpec(creation bool, local, remote *corev1.PodSpec, mutators ...Rem
 	// present, and the remote creation would fail as the corresponding service account is not present.
 	remote.AutomountServiceAccountToken = ptr.To(false)
 
-	// This fields are currently forced to false, to prevent invasive settings on the remote cluster (which might not work).
-	remote.HostIPC = false
-	remote.HostNetwork = false
-	remote.HostPID = false
+	remote.HostIPC = local.HostIPC
+	remote.HostNetwork = local.HostNetwork
+	remote.HostPID = local.HostPID
 
 	// Perform the additional mutations to implement advanced functionalities.
 	for _, mutator := range mutators {


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Enables propagation of `HostIPC`, `HostNetwork`, and `HostPID` fields from the local pod spec to the remote pod spec during virtual kubelet forging.

### Why
Previously these privileged fields were unconditionally forced to `false`, preventing pods that legitimately require host namespaces from functioning correctly on the remote cluster.

### Key changes
- `pkg/virtualKubelet/forge/pods.go`: Updated `RemotePodSpec` to copy `local.HostIPC`, `local.HostNetwork`, and `local.HostPID` directly to the remote spec instead of hardcoding them to `false`.

### Impact
Privileged pods using host namespaces will now retain those settings on the remote cluster. Ensure the remote cluster's security policies and admission controllers can accommodate these elevated privileges.