### PR TITLE
Disable host network for edge pods

### DIFF
--- a/pkg/virtualKubelet/forge/pods.go
+++ b/pkg/virtualKubelet/forge/pods.go
@@ -242,8 +242,9 @@ func RemotePodSpec(creation bool, local, remote *corev1.PodSpec, mutators ...Rem
 	remote.AutomountServiceAccountToken = ptr.To(false)
 
 	remote.HostIPC = local.HostIPC
-	remote.HostNetwork = local.HostNetwork
 	remote.HostPID = local.HostPID
+	// TODO: Add support for host network
+	remote.HostNetwork = false
 
 	// Perform the additional mutations to implement advanced functionalities.
 	for _, mutator := range mutators {


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Forces `HostNetwork` to `false` for all reflected remote pods, removing the previous behavior of mirroring the local pod's host network setting to the remote cluster.

### Why
Host network is not yet supported for offloaded pods. Mirroring the local value could create invalid or insecure pod specifications in the remote cluster.

### Key changes
- `pkg/virtualKubelet/forge/pods.go`: In `RemotePodSpec`, changed `remote.HostNetwork` assignment from `local.HostNetwork` to `false` and added a `TODO` noting future support.

### Impact
Workloads configured with `hostNetwork: true` will run without host network access in the remote cluster. This is a breaking change for any pods that rely on host networking until explicit support is added.