### PR TITLE
feat: support OMNI storage classes

### DIFF
--- a/pkg/consts/storage.go
+++ b/pkg/consts/storage.go
@@ -28,4 +28,7 @@ const (
 
 	// StorageNamespaceLabel is the label used to mark the liqo storage namespace.
 	StorageNamespaceLabel = "liqo.io/storage-provisioner"
+
+	// OmniStorageClassPrefix is the prefix used to mark OMNI storage classes.
+	OmniStorageClassPrefix = "omni-"
 )

--- a/pkg/liqo-controller-manager/offloading/storageprovisioner/remoteprovisioner.go
+++ b/pkg/liqo-controller-manager/offloading/storageprovisioner/remoteprovisioner.go
@@ -35,7 +35,7 @@ import (
 // ProvisionRemotePVC ensures the existence of a remote PVC and returns a virtual PV for that remote storage device.
 func ProvisionRemotePVC(ctx context.Context,
 	options controller.ProvisionOptions,
-	remoteNamespace, remoteRealStorageClass string,
+	remoteNamespace, localVirtualStorageClass, remoteRealStorageClass string,
 	remotePvcLister corev1listers.PersistentVolumeClaimNamespaceLister,
 	remotePvcClient corev1clients.PersistentVolumeClaimInterface,
 	forgingOpts *forge.ForgingOpts) (*corev1.PersistentVolume, controller.ProvisioningState, error) {
@@ -48,6 +48,10 @@ func ProvisionRemotePVC(ctx context.Context,
 	switch {
 	case apierrors.IsNotFound(err):
 		remoteStorageClass = remoteRealStorageClass
+		// if the local storage class is an OMNI one, we need to remove the prefix to get the real remote storage class
+		if strings.HasPrefix(localVirtualStorageClass, consts.OmniStorageClassPrefix) {
+			remoteStorageClass = strings.TrimPrefix(localVirtualStorageClass, consts.OmniStorageClassPrefix)
+		}
 	case err != nil && !apierrors.IsNotFound(err):
 		return nil, controller.ProvisioningInBackground, err
 	case remotePvc.Spec.StorageClassName != nil:

--- a/pkg/virtualKubelet/reflection/storage/controller.go
+++ b/pkg/virtualKubelet/reflection/storage/controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -65,7 +66,8 @@ func (npvcr *NamespacedPersistentVolumeClaimReflector) shouldProvision(claim *co
 	if provisioner, found := claim.Annotations[annStorageProvisioner]; found {
 		if npvcr.knownProvisioner(provisioner) {
 			claimClass := util.GetPersistentVolumeClaimClass(claim)
-			if claimClass != npvcr.virtualStorageClassName {
+			// We need to provision if storage class is liqo or omni one.
+			if claimClass != npvcr.virtualStorageClassName && !strings.HasPrefix(claimClass, consts.OmniStorageClassPrefix) {
 				return false, nil
 			}
 

--- a/pkg/virtualKubelet/reflection/storage/persistentvolumeclaim.go
+++ b/pkg/virtualKubelet/reflection/storage/persistentvolumeclaim.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/utils/trace"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/v7/controller"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v7/util"
 
 	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
@@ -188,7 +189,8 @@ func (npvcr *NamespacedPersistentVolumeClaimReflector) Handle(ctx context.Contex
 			}
 
 			pv, state, err := liqostorageprovisioner.ProvisionRemotePVC(ctx,
-				options, npvcr.RemoteNamespace(), npvcr.remoteRealStorageClassName,
+				options, npvcr.RemoteNamespace(),
+				util.GetPersistentVolumeClaimClass(local), npvcr.remoteRealStorageClassName,
 				npvcr.remotePersistentVolumeClaims, npvcr.remotePersistentVolumesClaimsClient,
 				npvcr.ForgingOpts)
 			if err == nil && state == controller.ProvisioningFinished {


### PR DESCRIPTION
# Description

Support OMNI storage classes

---
### Kimchi Summary
### What changed
This PR adds support for OMNI storage classes in Liqo’s storage reflection and remote provisioning flow. PVCs that reference a storage class prefixed with `omni-` are now treated as Liqo-managed storage and are provisioned remotely using the real storage class name with the prefix stripped.

### Why
Previously, only the configured Liqo virtual storage class was recognized during offloading, so OMNI-tagged storage classes could not be reflected and provisioned correctly across clusters.

### Key changes
- `pkg/consts/storage.go`: Added `OmniStorageClassPrefix = "omni-"` constant.
- `pkg/liqo-controller-manager/offloading/storageprovisioner/remoteprovisioner.go`: Updated `ProvisionRemotePVC` signature to accept `localVirtualStorageClass`; when the local class starts with `omni-`, the remote PVC now uses the trimmed class name as the real storage class.
- `pkg/virtualKubelet/reflection/storage/controller.go`: Updated `shouldProvision` so PVCs using either the Liqo virtual storage class or any `omni-` prefixed class are candidates for remote provisioning.
- `pkg/virtualKubelet/reflection/storage/persistentvolumeclaim.go`: Pass the local PVC’s storage class (`util.GetPersistentVolumeClaimClass(local)`) into `ProvisionRemotePVC`.

### Impact
- `ProvisionRemotePVC` now has an additional required parameter, so any external callers of this function must be updated.
- No migration steps are needed for normal Liqo users; the change is additive and only affects PVCs referencing `omni-` prefixed storage classes.