### PR TITLE
feat(route): add ECMP support on RouteConfigurations

### DIFF
--- a/apis/networking/v1beta1/routeconfiguration_types.go
+++ b/apis/networking/v1beta1/routeconfiguration_types.go
@@ -51,7 +51,25 @@ const (
 	NowhereScope Scope = "nowhere"
 )
 
+// NextHop is a single next-hop in a multipath route (ECMP).
+type NextHop struct {
+	// Gw is the gateway (next hop) IP address.
+	// +kubebuilder:validation:Required
+	Gw IP `json:"gw"`
+	// Dev is the local network interface through which this next-hop is reachable.
+	// +kubebuilder:validation:Required
+	Dev string `json:"dev"`
+	// Weight is the weight of this next-hop for load balancing.
+	// Higher weight means more traffic.
+	// Default is 0, which is translated to a kernel weight of 1.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=255
+	// +kubebuilder:default=0
+	Weight *int `json:"weight,omitempty"`
+}
+
 // Route is the route of the RouteConfiguration.
+// +kubebuilder:validation:XValidation:rule="!(has(self.gw) && has(self.nextHops))",message="cannot specify both gw and nextHops"
 type Route struct {
 	// Dst is the destination of the RouteConfiguration.
 	Dst *CIDR `json:"dst"`
@@ -59,9 +77,13 @@ type Route struct {
 	Src *IP `json:"src,omitempty"`
 	// Gw is the gateway of the RouteConfiguration.
 	Gw *IP `json:"gw,omitempty"`
+	// NextHops is the list of next-hops for ECMP (Equal-Cost Multi-Path) routing.
+	// Mutually exclusive with Gw.
+	// +optional
+	NextHops []NextHop `json:"nextHops,omitempty"`
 	// Dev is the device of the RouteConfiguration.
 	Dev *string `json:"dev,omitempty"`
-	// Onlink enables the onlink falg inside the route.
+	// Onlink enables the onlink flag inside the route.
 	Onlink *bool `json:"onlink,omitempty"`
 	// Scope is the scope of the RouteConfiguration.
 	// +kubebuilder:validation:Enum=global;link;host;site;nowhere

--- a/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_routeconfigurations.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_routeconfigurations.yaml
@@ -96,8 +96,39 @@ spec:
                                 description: Gw is the gateway of the RouteConfiguration.
                                 format: ipv4
                                 type: string
+                              nextHops:
+                                description: |-
+                                  NextHops is the list of next-hops for ECMP (Equal-Cost Multi-Path) routing.
+                                  Mutually exclusive with Gw.
+                                items:
+                                  description: NextHop is a single next-hop in a multipath
+                                    route (ECMP).
+                                  properties:
+                                    dev:
+                                      description: Dev is the local network interface
+                                        through which this next-hop is reachable.
+                                      type: string
+                                    gw:
+                                      description: Gw is the gateway (next hop) IP
+                                        address.
+                                      format: ipv4
+                                      type: string
+                                    weight:
+                                      default: 0
+                                      description: |-
+                                        Weight is the weight of this next-hop for load balancing.
+                                        Higher weight means more traffic.
+                                        Default is 0, which is translated to a kernel weight of 1.
+                                      maximum: 255
+                                      minimum: 0
+                                      type: integer
+                                  required:
+                                  - dev
+                                  - gw
+                                  type: object
+                                type: array
                               onlink:
-                                description: Onlink enables the onlink falg inside
+                                description: Onlink enables the onlink flag inside
                                   the route.
                                 type: boolean
                               scope:
@@ -161,6 +192,9 @@ spec:
                             required:
                             - dst
                             type: object
+                            x-kubernetes-validations:
+                            - message: cannot specify both gw and nextHops
+                              rule: '!(has(self.gw) && has(self.nextHops))'
                           type: array
                         src:
                           description: Src is the source of the Rule.

--- a/deployments/liqo/files/liqo-gateway-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-gateway-ClusterRole.yaml
@@ -1,79 +1,86 @@
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - networking.liqo.io
-    resources:
-      - connections
-      - publickeies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - update
-      - watch
-  - apiGroups:
-      - networking.liqo.io
-    resources:
-      - connections/status
-      - genevetunnels/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - networking.liqo.io
-    resources:
-      - firewallconfigurationbindings
-      - routeconfigurationbindings
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - networking.liqo.io
-    resources:
-      - firewallconfigurationbindings/finalizers
-      - firewallconfigurations/finalizers
-      - routeconfigurationbindings/finalizers
-      - routeconfigurations/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - networking.liqo.io
-    resources:
-      - firewallconfigurationbindings/status
-      - firewallconfigurations
-      - genevetunnels
-      - routeconfigurationbindings/status
-      - routeconfigurations
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - networking.liqo.io
-    resources:
-      - internalfabrics
-      - internalnodes
-    verbs:
-      - get
-      - list
-      - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - networking.liqo.io
+  resources:
+  - connections
+  - publickeies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - networking.liqo.io
+  resources:
+  - connections/status
+  - genevetunnels/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.liqo.io
+  resources:
+  - firewallconfigurationbindings
+  - routeconfigurationbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.liqo.io
+  resources:
+  - firewallconfigurationbindings/finalizers
+  - firewallconfigurations/finalizers
+  - routeconfigurationbindings/finalizers
+  - routeconfigurations/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - networking.liqo.io
+  resources:
+  - firewallconfigurationbindings/status
+  - firewallconfigurations
+  - genevetunnels
+  - routeconfigurationbindings/status
+  - routeconfigurations
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.liqo.io
+  resources:
+  - internalfabrics
+  - internalnodes
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
+	"k8s.io/utils/ptr"
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 )
@@ -133,6 +134,25 @@ func IsEqualRoute(route1, route2 *netlink.Route) bool {
 	if route1.Flags != route2.Flags {
 		return false
 	}
+	multipathLen1 := len(route1.MultiPath)
+	multipathLen2 := len(route2.MultiPath)
+	if multipathLen1 > 0 || multipathLen2 > 0 {
+		if multipathLen1 != multipathLen2 {
+			return false
+		}
+		for _, nh1 := range route1.MultiPath {
+			found := false
+			for _, nh2 := range route2.MultiPath {
+				if nh1.Equal(*nh2) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+	}
 	return true
 }
 
@@ -196,14 +216,10 @@ func forgeNetlinkRoute(route *networkingv1beta1.Route, tableID uint32) (*netlink
 	}
 
 	if route.Dev != nil {
-		link, err := netlink.LinkByName(*route.Dev)
+		linkIndex, err = getLinkIDByName(*route.Dev)
 		if err != nil {
-			if errors.As(err, &netlink.LinkNotFoundError{}) {
-				return nil, fmt.Errorf("link %s not found: %w", *route.Dev, err)
-			}
-			return nil, fmt.Errorf("getting link %s: %w", *route.Dev, err)
+			return nil, err
 		}
-		linkIndex = link.Attrs().Index
 	}
 
 	if route.Onlink != nil && *route.Onlink {
@@ -225,14 +241,48 @@ func forgeNetlinkRoute(route *networkingv1beta1.Route, tableID uint32) (*netlink
 		default:
 		}
 	}
+	var multiPath []*netlink.NexthopInfo
+	if len(route.NextHops) > 0 {
+		// MultiPath (ECMP) routes must not have a main gateway or a main link index
+		// All next-hop specific information is contained within the MultiPath slice.
+		gw = nil
+		linkIndex = 0
+		multiPath = make([]*netlink.NexthopInfo, len(route.NextHops))
+		for i, nh := range route.NextHops {
+			nextHopGw := net.ParseIP(nh.Gw.String())
+			weight := ptr.Deref(nh.Weight, 0)
+			linkID, err := getLinkIDByName(nh.Dev)
+			if err != nil {
+				return nil, fmt.Errorf("getting link for nexthop %d: %w", i, err)
+			}
+
+			multiPath[i] = &netlink.NexthopInfo{
+				Gw:        nextHopGw,
+				LinkIndex: linkID,
+				Hops:      weight,
+			}
+		}
+	}
 
 	return &netlink.Route{
 		Dst:       dst,
 		Gw:        gw,
+		MultiPath: multiPath,
 		Src:       src,
 		LinkIndex: linkIndex,
 		Table:     int(tableID),
 		Flags:     flags,
 		Scope:     scope,
 	}, nil
+}
+
+func getLinkIDByName(name string) (int, error) {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		if errors.As(err, &netlink.LinkNotFoundError{}) {
+			return 0, fmt.Errorf("link %s not found: %w", name, err)
+		}
+		return 0, fmt.Errorf("getting link with name %q: %w", name, err)
+	}
+	return link.Attrs().Index, nil
 }


### PR DESCRIPTION
This PR extends the semantics of the RouteConfiguration CR by introducing a new NextHop struct used to specify the hops of a multipath route. The struct contains a gateway IP and an associated weight. The weight indicates how much traffic should pass through that hop.
A new field, NextHops []NextHop, has been added to the Route struct as an alternative to the existing Gw field. This allows configuring multiple paths for the same destination.
