### PR TITLE
feat: invalidate ECMP route when connection fails

### DIFF
--- a/build/liqo/Dockerfile
+++ b/build/liqo/Dockerfile
@@ -4,9 +4,14 @@ FROM alpine:3.20
 ARG COMPONENT
 ARG TARGETARCH
 
-RUN if [ "$COMPONENT" = "geneve" ] || [ "$COMPONENT" = "wireguard" ] || [ "$COMPONENT" = "gateway" ]; then \
-    set -x; \
-    apk add --no-cache iproute2 nftables bash wireguard-tools tcpdump conntrack-tools curl iputils; \
+RUN set -e; \
+    if [ "$COMPONENT" = "geneve" ] || [ "$COMPONENT" = "wireguard" ] || [ "$COMPONENT" = "gateway" ] || [ "$COMPONENT" = "fabric" ]; then \
+        set -x; \
+        apk add --no-cache iproute2 nftables bash tcpdump conntrack-tools curl iputils; \
+    fi; \
+    if [ "$COMPONENT" = "wireguard" ]; then \
+        set -x; \
+        apk add --no-cache wireguard-tools; \
     fi
 
 # Copy the correct binary for the architecture

--- a/pkg/liqo-controller-manager/networking/internal-network/internalfabric-controller/internalfabric_controller.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/internalfabric-controller/internalfabric_controller.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -57,6 +58,7 @@ func NewInternalFabricReconciler(cl client.Client, s *runtime.Scheme, routeConfi
 // +kubebuilder:rbac:groups=networking.liqo.io,resources=genevetunnels/finalizers,verbs=update
 // +kubebuilder:rbac:groups=networking.liqo.io,resources=internalnodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.liqo.io,resources=internalnodes/finalizers,verbs=update
+// +kubebuilder:rbac:groups=networking.liqo.io,resources=connections,verbs=get;list;watch
 
 // Reconcile manage InternalFabric lifecycle.
 func (r *InternalFabricReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -135,9 +137,45 @@ func (r *InternalFabricReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	)
 
+	connectionEnqueuer := handler.EnqueueRequestsFromMapFunc(
+		func(ctx context.Context, obj client.Object) []reconcile.Request {
+			conn, ok := obj.(*networkingv1beta1.Connection)
+			if !ok {
+				return nil
+			}
+
+			gatewayNamespace := conn.Spec.GatewayRef.Namespace
+			if gatewayNamespace == "" {
+				gatewayNamespace = conn.Namespace
+			}
+
+			var internalFabricList networkingv1beta1.InternalFabricList
+			if err := r.List(ctx, &internalFabricList, client.InNamespace(gatewayNamespace)); err != nil {
+				klog.Errorf("Unable to list InternalFabrics: %s", err)
+				return nil
+			}
+
+			var requests []reconcile.Request
+			for i := range internalFabricList.Items {
+				internalFabric := &internalFabricList.Items[i]
+				owner := metav1.GetControllerOf(internalFabric)
+				if owner == nil || owner.Name != conn.Spec.GatewayRef.Name {
+					continue
+				}
+
+				requests = append(requests, reconcile.Request{
+					NamespacedName: client.ObjectKeyFromObject(internalFabric),
+				})
+			}
+
+			return requests
+		},
+	)
+
 	return ctrl.NewControllerManagedBy(mgr).Named(consts.CtrlInternalFabricCM).
 		For(&networkingv1beta1.InternalFabric{}).
 		Watches(&networkingv1beta1.InternalNode{}, internalNodeEnqueuer).
+		Watches(&networkingv1beta1.Connection{}, connectionEnqueuer).
 		Owns(&networkingv1beta1.RouteConfiguration{}).
 		Owns(&networkingv1beta1.GeneveTunnel{}).
 		Complete(r)

--- a/pkg/liqo-controller-manager/networking/internal-network/internalfabric-controller/route.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/internalfabric-controller/route.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"sort"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,11 +30,13 @@ import (
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/fabric"
+	"github.com/liqotech/liqo/pkg/gateway/forge"
 	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 func (r *InternalFabricReconciler) ensureRouteConfiguration(ctx context.Context, internalFabric *networkingv1beta1.InternalFabric) error {
 	replicas := internalFabric.Spec.Replicas
+	deprecated := false
 	if len(replicas) == 0 {
 		if internalFabric.Spec.Interface == nil {
 			return fmt.Errorf("internal fabric %q has no replicas and no deprecated interface", client.ObjectKeyFromObject(internalFabric))
@@ -40,6 +44,7 @@ func (r *InternalFabricReconciler) ensureRouteConfiguration(ctx context.Context,
 		replicas = []networkingv1beta1.InternalFabricReplica{
 			{Interface: *internalFabric.Spec.Interface},
 		}
+		deprecated = true
 	}
 
 	for i := range replicas {
@@ -53,6 +58,19 @@ func (r *InternalFabricReconciler) ensureRouteConfiguration(ctx context.Context,
 	sort.Slice(replicas, func(i, j int) bool {
 		return replicas[i].ReplicaID < replicas[j].ReplicaID
 	})
+
+	// Filter out replicas whose Connection is not in Connected state.
+	// For the deprecated single-interface path we cannot map to a Connection,
+	// so we keep the existing behavior.
+	connectedReplicas := replicas
+	if !deprecated {
+		filtered, err := r.connectedReplicas(ctx, internalFabric, replicas)
+		if err != nil {
+			return fmt.Errorf("filtering connected replicas for internal fabric %q: %w",
+				client.ObjectKeyFromObject(internalFabric), err)
+		}
+		connectedReplicas = filtered
+	}
 
 	route := &networkingv1beta1.RouteConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
@@ -74,9 +92,9 @@ func (r *InternalFabricReconciler) ensureRouteConfiguration(ctx context.Context,
 			priority = ptr.To(r.RouteConfigurationRulePriority)
 		}
 
-		// Add a link-scope route for each replica's gateway inner IP.
-		for i := range replicas {
-			replica := &replicas[i]
+		// Add a link-scope route for each connected replica's gateway inner IP.
+		for i := range connectedReplicas {
+			replica := &connectedReplicas[i]
 			rules = append(rules, networkingv1beta1.Rule{
 				Dst:      ptr.To(networkingv1beta1.CIDR(fmt.Sprintf("%s/32", replica.Interface.Gateway.IP))),
 				Priority: priority,
@@ -97,17 +115,17 @@ func (r *InternalFabricReconciler) ensureRouteConfiguration(ctx context.Context,
 		})
 
 		// Add one rule per remote CIDR.
-		// Use a classic single gateway when there is only one replica, otherwise use ECMP next-hops.
+		// Use a classic single gateway when there is only one connected replica, otherwise use ECMP next-hops.
 		for _, remoteCIDR := range remoteCIDRs {
 			var route networkingv1beta1.Route
 			route.Dst = ptr.To(remoteCIDR)
 
-			if len(replicas) == 1 {
-				route.Gw = ptr.To(replicas[0].Interface.Gateway.IP)
+			if len(connectedReplicas) == 1 {
+				route.Gw = ptr.To(connectedReplicas[0].Interface.Gateway.IP)
 			} else {
-				nextHops := make([]networkingv1beta1.NextHop, 0, len(replicas))
-				for i := range replicas {
-					replica := &replicas[i]
+				nextHops := make([]networkingv1beta1.NextHop, 0, len(connectedReplicas))
+				for i := range connectedReplicas {
+					replica := &connectedReplicas[i]
 					nextHops = append(nextHops, networkingv1beta1.NextHop{
 						Gw:  replica.Interface.Gateway.IP,
 						Dev: replica.Interface.Node.Name,
@@ -138,6 +156,55 @@ func (r *InternalFabricReconciler) ensureRouteConfiguration(ctx context.Context,
 	}
 
 	return nil
+}
+
+// connectedReplicas returns the subset of replicas whose related Connection resource is in Connected state.
+func (r *InternalFabricReconciler) connectedReplicas(ctx context.Context,
+	internalFabric *networkingv1beta1.InternalFabric, replicas []networkingv1beta1.InternalFabricReplica) (
+	[]networkingv1beta1.InternalFabricReplica, error) {
+	gatewayName, ok := gatewayNameFromOwnerRef(internalFabric)
+	if !ok {
+		klog.V(4).Infof("InternalFabric %q has no gateway owner reference, cannot filter by Connection state",
+			client.ObjectKeyFromObject(internalFabric))
+		return replicas, nil
+	}
+
+	connected := make([]networkingv1beta1.InternalFabricReplica, 0, len(replicas))
+	for i := range replicas {
+		replica := &replicas[i]
+		connectionName := forge.ReplicaResourceName(gatewayName, replica.ReplicaID)
+		connection := &networkingv1beta1.Connection{}
+		if err := r.Get(ctx, types.NamespacedName{
+			Namespace: internalFabric.Namespace,
+			Name:      connectionName,
+		}, connection); err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.V(4).Infof("Connection %q/%q not found, skipping replica %d",
+					internalFabric.Namespace, connectionName, replica.ReplicaID)
+				continue
+			}
+			return nil, fmt.Errorf("getting Connection %q/%q: %w",
+				internalFabric.Namespace, connectionName, err)
+		}
+
+		if connection.Status.Value == networkingv1beta1.Connected {
+			connected = append(connected, *replica)
+		} else {
+			klog.V(4).Infof("Connection %q/%q status is %q, skipping replica %d",
+				internalFabric.Namespace, connectionName, connection.Status.Value, replica.ReplicaID)
+		}
+	}
+
+	return connected, nil
+}
+
+// gatewayNameFromOwnerRef returns the name of the gateway owner reference of the InternalFabric.
+func gatewayNameFromOwnerRef(internalFabric *networkingv1beta1.InternalFabric) (string, bool) {
+	owner := metav1.GetControllerOf(internalFabric)
+	if owner == nil {
+		return "", false
+	}
+	return owner.Name, true
 }
 
 // GenerateRouteConfigurationName returns the name of the RouteConfiguration associated to the InternalFabric.


### PR DESCRIPTION
## Summary

When a gateway replica's `Connection` resource is no longer in the `Connected` state, its ECMP next-hop must be removed from the internal-network RouteConfiguration. Otherwise traffic continues to be black-holed through a failed replica.

This PR makes the `InternalFabric` controller watch `Connection` resources and compute routes only over replicas whose connection is currently `Connected`.

## Changes

### InternalFabric controller

- **`pkg/liqo-controller-manager/networking/internal-network/internalfabric-controller/internalfabric_controller.go`**
  - Added RBAC permissions to watch `Connection` resources.
  - Registered a `Connection` watch in `SetupWithManager` that enqueues the owning `InternalFabric`.
  - The mapper resolves the `Connection` → gateway → `InternalFabric` relationship using the controller owner reference.

### Route generation

- **`pkg/liqo-controller-manager/networking/internal-network/internalfabric-controller/route.go`**
  - Added `connectedReplicas()` helper: for each replica it looks up the corresponding `Connection` by name (`<gateway>-<replicaID>`) and keeps only replicas whose `Status.Value == Connected`.
  - Route and next-hop generation now iterates over `connectedReplicas` instead of the raw `Spec.Replicas` list.
  - Classic single-gateway behavior is preserved when exactly one replica is connected.
  - ECMP `nextHops` are generated only when two or more replicas are connected.
  - Link-scope routes for each replica's gateway inner IP are also restricted to connected replicas.

### Dockerfile

- **`build/liqo/Dockerfile`**
  - Installed common network tools (`iproute2`, `nftables`, `tcpdump`, `conntrack-tools`, `curl`, `iputils`) for both `fabric` and gateway components.
  - Installed `wireguard-tools` only for the `wireguard` component, avoiding unnecessary packages in the fabric image.

## Notes

- The deprecated single-interface path is excluded from connection-state filtering because there is no associated `Connection` resource to check.
- This change relies on the `Connection` status being updated by the gateway controllers; once a connection is restored, the replica is automatically re-added to the ECMP group.
